### PR TITLE
Allow username for signin

### DIFF
--- a/operations-automation/aws-services-lifecycle-tracker/cdk/lib/auth-stack.ts
+++ b/operations-automation/aws-services-lifecycle-tracker/cdk/lib/auth-stack.ts
@@ -21,6 +21,7 @@ export class AuthStack extends cdk.Stack {
             userPoolName: 'aws-services-lifecycle-tracker-admin-users',
             selfSignUpEnabled: false, // DISABLED - Admin only
             signInAliases: {
+                username: true,
                 email: true,
             },
             autoVerify: {


### PR DESCRIPTION
Summary
Enables username-based authentication in addition to email for the AWS Services Lifecycle Tracker Cognito User Pool.

Problem
Previously, the Cognito User Pool was configured to only accept email addresses as sign-in aliases. This caused the following error when attempting to create users with non-email usernames:

An error occurred (InvalidParameterException) when calling the AdminCreateUser operation: Username should be an email.
Solution
Added username: true to the signInAliases configuration in the AuthStack, allowing users to sign in with either:

Username (e.g., admin)
Email address (e.g., admin@company.com)
