### PR TITLE
Fix: Retrieve CloudFormation outputs before S3 uploads in bash script

### DIFF
--- a/cost-optimization/ai-graviton-migration-assessment/assess-graviton.sh
+++ b/cost-optimization/ai-graviton-migration-assessment/assess-graviton.sh
@@ -107,6 +107,19 @@ if [ "$SKIP_SETUP" = false ]; then
         exit 1
     fi
 
+    # Get bucket name and project name from CloudFormation outputs
+    echo ""
+    echo "Getting stack outputs..."
+    STACK_NAME="GravitonAssessmentStack-$CURRENT_REGION"
+    OUTPUT_BUCKET=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$CURRENT_REGION" --no-cli-pager --query "Stacks[0].Outputs[?OutputKey=='OutputBucketName'].OutputValue" --output text)
+    PROJECT_NAME=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$CURRENT_REGION" --no-cli-pager --query "Stacks[0].Outputs[?OutputKey=='CodeBuildProjectName'].OutputValue" --output text)
+    if [[ -z "$OUTPUT_BUCKET" || -z "$PROJECT_NAME" ]]; then
+        echo "      ❌ Failed to get stack outputs"
+        exit 1
+    fi
+    echo "      Output Bucket: $OUTPUT_BUCKET"
+    echo "      CodeBuild Project: $PROJECT_NAME"
+
     # Upload buildspec to S3
     echo ""
     echo "Uploading buildspec to S3..."


### PR DESCRIPTION
*Description of changes:*

- Moved CloudFormation output retrieval to immediately after CDK deployment
- Ensures OUTPUT_BUCKET variable is populated before S3 upload operations
- Aligns bash script sequence with PowerShell script implementation
- Fixes 'Invalid bucket name' error during buildspec upload

*Issue #4 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
