### PR TITLE
Fix:/cost-optimization/ai-graviton-migration-assessment path

### DIFF
--- a/cost-optimization/ai-graviton-migration-assessment/README.md
+++ b/cost-optimization/ai-graviton-migration-assessment/README.md
@@ -55,7 +55,7 @@ GitHub Repo → CodeBuild (AWS Transform AI) → S3 (Assessment + Artifacts)
 
 ```bash
 # Analyze your repository
-cd cost-optimization/graviton-migration-assessment
+cd cost-optimization/ai-graviton-migration-assessment
 ./assess-graviton.ps1 -RepositoryUrl "https://github.com/owner/repo"
 
 # Or use the default sample (serverless payments app)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
minor typo in the instructions:

```bash
# Analyze your repository
cd cost-optimization/ai-graviton-migration-assessment
./assess-graviton.ps1 -RepositoryUrl "https://github.com/owner/repo"

 the instructions originally had cd cost-optimization/graviton-migration-assessment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
