### PR TITLE
fix: remove unregistered PyPI package mactypes

### DIFF
--- a/operations-automation/ai-legacy-system-browser-automation/mail-polling/requirements.txt
+++ b/operations-automation/ai-legacy-system-browser-automation/mail-polling/requirements.txt
@@ -23,7 +23,6 @@ plyer>=2.1.0; sys_platform == "win32"
 
 # Mail monkey dependencies - macOS
 appscript>=1.2.0; sys_platform == "darwin"
-mactypes>=1.2; sys_platform == "darwin"
 pyobjc-framework-Cocoa>=10.0; sys_platform == "darwin"
 
 # Mail monkey dependencies - Cross-platform


### PR DESCRIPTION
Remove `mactypes` from `requirements.txt` — this package is not used by the sample.
