### PR TITLE
fix: resolve S3 bucket name regression and improve cross-platform support

### DIFF
--- a/cost-optimization/ai-graviton-migration-assessment/README.md
+++ b/cost-optimization/ai-graviton-migration-assessment/README.md
@@ -53,13 +53,26 @@ GitHub Repo → CodeBuild (AWS Transform AI) → S3 (Assessment + Artifacts)
 
 ## Quick Start
 
+**Linux/macOS:**
 ```bash
-# Analyze your repository
 cd cost-optimization/ai-graviton-migration-assessment
-./assess-graviton.ps1 -RepositoryUrl "https://github.com/owner/repo"
+
+# Analyze your repository
+./assess-graviton.sh -r "https://github.com/owner/repo"
 
 # Or use the default sample (serverless payments app)
-./assess-graviton.ps1
+./assess-graviton.sh
+```
+
+**Windows (PowerShell):**
+```powershell
+cd cost-optimization\ai-graviton-migration-assessment
+
+# Analyze your repository
+.\assess-graviton.ps1 -RepositoryUrl "https://github.com/owner/repo"
+
+# Or use the default sample (serverless payments app)
+.\assess-graviton.ps1
 ```
 
 The script automatically:
@@ -99,8 +112,17 @@ This demo enhances AI analysis by dynamically downloading the latest guidance fr
 
 ## Cleanup
 
+**Linux/macOS:**
 ```bash
 cd infrastructure/cdk
+export PYTHONPATH=$(cd ../../../.. && pwd)
+npx cdk destroy
+```
+
+**Windows (PowerShell):**
+```powershell
+cd infrastructure\cdk
+$env:PYTHONPATH = (Resolve-Path ..\..\..\..)
 npx cdk destroy
 ```
 

--- a/cost-optimization/ai-graviton-migration-assessment/assess-graviton.sh
+++ b/cost-optimization/ai-graviton-migration-assessment/assess-graviton.sh
@@ -107,6 +107,19 @@ if [ "$SKIP_SETUP" = false ]; then
         exit 1
     fi
 
+    # Get bucket name and project name from CloudFormation outputs
+    echo ""
+    echo "Getting stack outputs..."
+    STACK_NAME="GravitonAssessmentStack-$CURRENT_REGION"
+    OUTPUT_BUCKET=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$CURRENT_REGION" --no-cli-pager --query "Stacks[0].Outputs[?OutputKey=='OutputBucketName'].OutputValue" --output text)
+    PROJECT_NAME=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$CURRENT_REGION" --no-cli-pager --query "Stacks[0].Outputs[?OutputKey=='CodeBuildProjectName'].OutputValue" --output text)
+    if [[ -z "$OUTPUT_BUCKET" || -z "$PROJECT_NAME" ]]; then
+        echo "      ❌ Failed to get stack outputs"
+        exit 1
+    fi
+    echo "      Output Bucket: $OUTPUT_BUCKET"
+    echo "      CodeBuild Project: $PROJECT_NAME"
+
     # Upload buildspec to S3
     echo ""
     echo "Uploading buildspec to S3..."
@@ -153,21 +166,23 @@ else
     echo "      Region: $CURRENT_REGION"
 fi
 
-# Get bucket name and project name from CloudFormation outputs
-echo ""
-echo "Getting stack outputs..."
-STACK_NAME="GravitonAssessmentStack-$CURRENT_REGION"
-OUTPUT_BUCKET=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$CURRENT_REGION" --no-cli-pager --query "Stacks[0].Outputs[?OutputKey=='OutputBucketName'].OutputValue" --output text)
-PROJECT_NAME=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$CURRENT_REGION" --no-cli-pager --query "Stacks[0].Outputs[?OutputKey=='CodeBuildProjectName'].OutputValue" --output text)
+# Get bucket name and project name from CloudFormation outputs (only if not already set from deploy path)
 if [[ -z "$OUTPUT_BUCKET" || -z "$PROJECT_NAME" ]]; then
-    echo "      ❌ Failed to get stack outputs"
-    if [ "$SKIP_SETUP" = true ]; then
-        echo "      Stack may not exist. Run without -s to deploy infrastructure first."
+    echo ""
+    echo "Getting stack outputs..."
+    STACK_NAME="GravitonAssessmentStack-$CURRENT_REGION"
+    OUTPUT_BUCKET=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$CURRENT_REGION" --no-cli-pager --query "Stacks[0].Outputs[?OutputKey=='OutputBucketName'].OutputValue" --output text)
+    PROJECT_NAME=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$CURRENT_REGION" --no-cli-pager --query "Stacks[0].Outputs[?OutputKey=='CodeBuildProjectName'].OutputValue" --output text)
+    if [[ -z "$OUTPUT_BUCKET" || -z "$PROJECT_NAME" ]]; then
+        echo "      ❌ Failed to get stack outputs"
+        if [ "$SKIP_SETUP" = true ]; then
+            echo "      Stack may not exist. Run without -s to deploy infrastructure first."
+        fi
+        exit 1
     fi
-    exit 1
+    echo "      Output Bucket: $OUTPUT_BUCKET"
+    echo "      CodeBuild Project: $PROJECT_NAME"
 fi
-echo "      Output Bucket: $OUTPUT_BUCKET"
-echo "      CodeBuild Project: $PROJECT_NAME"
 
 # Start Graviton assessment build
 echo ""

--- a/cost-optimization/ai-graviton-migration-assessment/infrastructure/cdk/cdk.json
+++ b/cost-optimization/ai-graviton-migration-assessment/infrastructure/cdk/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "python app.py",
+  "app": "python3 app.py",
   "watch": {
     "include": ["**"],
     "exclude": [


### PR DESCRIPTION
Fixes #4

- Re-apply CloudFormation output retrieval before S3 uploads in bash script (regression from merge commit 4760431)
- Use python3 in cdk.json for compatibility with systems without python alias
- Add Linux/macOS instructions to README alongside PowerShell
- Add PYTHONPATH guidance to cleanup section