### PR TITLE
fix(eks-investigation-devops-agent): fail-fast guards for region, CDK bootstrap, and S3 bucket mismatch

### DIFF
--- a/observability/eks-investigation-devops-agent/README.md
+++ b/observability/eks-investigation-devops-agent/README.md
@@ -45,6 +45,11 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full architecture docum
 - Node.js 20+ with npm
 - `zip` utility
 - Git
+- **CDK bootstrap** — the target account + region must be bootstrapped before running the deploy script. If you've never deployed CDK to this account/region pair, run:
+  ```bash
+  npx cdk bootstrap aws://<account-id>/<region>
+  ```
+  Bootstrapping creates the IAM roles, S3 bucket, ECR repo, and SSM parameter that CDK uses to publish assets and assume deploy roles. It's a one-time, idempotent operation per account/region. Without it, the deploy fails on the first stack with `SSM parameter /cdk-bootstrap/hnb659fds/version not found`.
 
 No local Docker or Java required — container images are built in the cloud via AWS CodeBuild.
 
@@ -61,16 +66,25 @@ cd sample-aws-genai-ops-demos/observability/eks-investigation-devops-agent
 
 > **⚠️ Interactive step required during deployment:** The script will pause and ask you to generate a DevOps Agent webhook from the AWS console. Have a browser ready — the script prints the exact console URL to open.
 
-> **DevOps Agent region:** By default, the Agent Space is created in `us-east-1` regardless of your current default region for all the other stacks. To use a different supported region:
-> ```powershell
-> # PowerShell
-> $env:DEVOPS_AGENT_REGION = "eu-west-1"
-> .\deploy-all.ps1
-> ```
+> **Two regions, set them both.** The deploy uses two independent region variables:
+>
+> - `AWS_REGION` — where the CDK stacks (EKS, RDS, CloudFront, etc.) are deployed. If unset, the AWS CLI falls back to `aws configure get region`, which may not be what you want.
+> - `DEVOPS_AGENT_REGION` — where the DevOps Agent Space is created. Defaults to `us-east-1` because `AWS::DevOpsAgent` resources are not available in every region.
+>
+> For a same-region deployment (example: Ireland):
 > ```bash
 > # Bash
+> export AWS_REGION=eu-west-1
+> export AWS_DEFAULT_REGION=eu-west-1
 > export DEVOPS_AGENT_REGION=eu-west-1
 > bash deploy-all.sh
+> ```
+> ```powershell
+> # PowerShell
+> $env:AWS_REGION = "eu-west-1"
+> $env:AWS_DEFAULT_REGION = "eu-west-1"
+> $env:DEVOPS_AGENT_REGION = "eu-west-1"
+> .\deploy-all.ps1
 > ```
 
 ```bash
@@ -317,7 +331,9 @@ All costs approximate, based on `us-east-1` pricing.
 | CloudFront returns **403** | S3/OAC misconfigured | Re-run deployment |
 | Agent Space not found | CLI too old | Upgrade AWS CLI to >= 2.34.21 |
 | Investigation shows "no AWS account access" | Missing association | Re-run `.\scripts\setup-devops-agent.ps1` |
+| CDK fails with **`SSM parameter /cdk-bootstrap/hnb659fds/version not found`** | Account/region is not CDK-bootstrapped | Run `npx cdk bootstrap aws://<account-id>/<region>` once, then re-run `deploy-all.sh` |
 | CDK bootstrap "S3 bucket already exists" | Broken CDK bootstrap stack | Run `npx cdk bootstrap --force` or delete the orphaned S3 bucket `cdk-hnb659fds-assets-*` and re-bootstrap. See [CDK bootstrap troubleshooting](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-troubleshoot.html) |
+| Deploy targeted the wrong region | `AWS_REGION` unset, so CLI fell back to `aws configure get region` | `export AWS_REGION=<intended-region>` and `export AWS_DEFAULT_REGION=<same>` before running the script |
 
 ## Recreating the Agent Space
 

--- a/observability/eks-investigation-devops-agent/README.md
+++ b/observability/eks-investigation-devops-agent/README.md
@@ -334,6 +334,7 @@ All costs approximate, based on `us-east-1` pricing.
 | CDK fails with **`SSM parameter /cdk-bootstrap/hnb659fds/version not found`** | Account/region is not CDK-bootstrapped | Run `npx cdk bootstrap aws://<account-id>/<region>` once, then re-run `deploy-all.sh` |
 | CDK bootstrap "S3 bucket already exists" | Broken CDK bootstrap stack | Run `npx cdk bootstrap --force` or delete the orphaned S3 bucket `cdk-hnb659fds-assets-*` and re-bootstrap. See [CDK bootstrap troubleshooting](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-troubleshoot.html) |
 | Deploy targeted the wrong region | `AWS_REGION` unset, so CLI fell back to `aws configure get region` | `export AWS_REGION=<intended-region>` and `export AWS_DEFAULT_REGION=<same>` before running the script |
+| CodeBuild fails in **DOWNLOAD_SOURCE** with `BucketRegionError` (builds fail in ~18s) | The CodeBuild sources S3 bucket (`devops-agent-eks-cfn-templates-<account>`) exists in a different region than this deploy, left over from a previous attempt. CodeBuild cannot pull sources cross-region. | Delete the misplaced bucket and re-run: `aws s3 rm s3://devops-agent-eks-cfn-templates-<account> --recursive --region <old-region>` then `aws s3 rb s3://devops-agent-eks-cfn-templates-<account> --region <old-region>`. The deploy script now detects this upfront. |
 
 ## Recreating the Agent Space
 

--- a/observability/eks-investigation-devops-agent/deploy-all.ps1
+++ b/observability/eks-investigation-devops-agent/deploy-all.ps1
@@ -92,6 +92,23 @@ Write-Host ""
 
 $ECR_REGISTRY = "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
 
+# ---------------------------------------------------------------------------
+# CDK bootstrap pre-flight
+# ---------------------------------------------------------------------------
+# The CDK deploy step (~15 min) fails late with a confusing "SSM parameter
+# /cdk-bootstrap/hnb659fds/version not found" error if this account/region has
+# never been bootstrapped. Check upfront so the user sees the fix in seconds.
+aws ssm get-parameter --name /cdk-bootstrap/hnb659fds/version --region $AWS_REGION --output text 2>$null | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host ""
+    Write-Host "ERROR: CDK is not bootstrapped in $AWS_REGION for account $AWS_ACCOUNT_ID." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Run this once, then re-run deploy-all.ps1:"
+    Write-Host "  npx cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_REGION"
+    Write-Host ""
+    exit 1
+}
+
 # =============================================================================
 # STEP 1: Install CDK dependencies and create S3 bucket for CodeBuild sources
 # =============================================================================

--- a/observability/eks-investigation-devops-agent/deploy-all.ps1
+++ b/observability/eks-investigation-devops-agent/deploy-all.ps1
@@ -116,6 +116,30 @@ Write-Host "[1/9] Installing CDK dependencies and preparing S3 bucket..." -Foreg
 $BUCKET_NAME = "$ProjectName-cfn-templates-$AWS_ACCOUNT_ID"
 aws s3 mb "s3://$BUCKET_NAME" --region $AWS_REGION 2>$null
 
+# Verify the bucket lives in the target region. S3 bucket names are globally
+# unique, so if a previous deploy attempt created this bucket in a different
+# region the 'mb' above silently no-ops. CodeBuild refuses cross-region source
+# downloads and would fail ~18s into the first build (DOWNLOAD_SOURCE phase)
+# with a BucketRegionError. Fail fast here with an actionable message.
+$BucketLocation = aws s3api get-bucket-location --bucket $BUCKET_NAME --query 'LocationConstraint' --output text 2>$null
+# us-east-1 reports as 'None' (historical quirk of the S3 API)
+if (-not $BucketLocation -or $BucketLocation -eq 'None') {
+    $BucketLocation = 'us-east-1'
+}
+if ($BucketLocation -ne $AWS_REGION) {
+    Write-Host ""
+    Write-Host "ERROR: S3 bucket '$BUCKET_NAME' exists in '$BucketLocation' but this deploy targets '$AWS_REGION'." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "This typically happens after a previous deploy attempt ran against a different region."
+    Write-Host "CodeBuild in '$AWS_REGION' cannot pull sources from a bucket in '$BucketLocation'."
+    Write-Host ""
+    Write-Host "Fix: delete the misplaced bucket, then re-run deploy-all.ps1:"
+    Write-Host "  aws s3 rm s3://$BUCKET_NAME --recursive --region $BucketLocation"
+    Write-Host "  aws s3 rb s3://$BUCKET_NAME --region $BucketLocation"
+    Write-Host ""
+    exit 1
+}
+
 Push-Location cdk; npm install; Pop-Location
 Write-Host "  done."
 Write-Host ""

--- a/observability/eks-investigation-devops-agent/deploy-all.ps1
+++ b/observability/eks-investigation-devops-agent/deploy-all.ps1
@@ -121,7 +121,30 @@ aws s3 mb "s3://$BUCKET_NAME" --region $AWS_REGION 2>$null
 # region the 'mb' above silently no-ops. CodeBuild refuses cross-region source
 # downloads and would fail ~18s into the first build (DOWNLOAD_SOURCE phase)
 # with a BucketRegionError. Fail fast here with an actionable message.
-$BucketLocation = aws s3api get-bucket-location --bucket $BUCKET_NAME --query 'LocationConstraint' --output text 2>$null
+#
+# Also handles the case where 'mb' failed for another reason (e.g., S3 name
+# cooldown after a recent DeleteBucket) so we abort instead of marching into
+# the CDK deploy with a bucket that doesn't exist.
+$BucketLocationRaw = (aws s3api get-bucket-location --bucket $BUCKET_NAME --query 'LocationConstraint' --output text 2>&1) -join "`n"
+$BucketLocationExit = $LASTEXITCODE
+
+if ($BucketLocationExit -ne 0) {
+    Write-Host ""
+    Write-Host "ERROR: Could not verify S3 bucket '$BUCKET_NAME'." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "  $BucketLocationRaw"
+    Write-Host ""
+    if ($BucketLocationRaw -match 'NoSuchBucket') {
+        Write-Host "The bucket does not exist. 'aws s3 mb' above likely failed silently."
+        Write-Host "A common cause is the S3 name-reuse cooldown after a recent DeleteBucket"
+        Write-Host "(can take several minutes). Wait a bit and re-run deploy-all.ps1, or try:"
+        Write-Host "  aws s3 mb s3://$BUCKET_NAME --region $AWS_REGION"
+    }
+    Write-Host ""
+    exit 1
+}
+
+$BucketLocation = $BucketLocationRaw
 # us-east-1 reports as 'None' (historical quirk of the S3 API)
 if (-not $BucketLocation -or $BucketLocation -eq 'None') {
     $BucketLocation = 'us-east-1'

--- a/observability/eks-investigation-devops-agent/deploy-all.sh
+++ b/observability/eks-investigation-devops-agent/deploy-all.sh
@@ -126,6 +126,31 @@ echo "[1/9] Installing CDK dependencies and preparing S3 bucket..."
 BUCKET_NAME="$PROJECT_NAME-cfn-templates-$AWS_ACCOUNT_ID"
 aws s3 mb "s3://$BUCKET_NAME" --region "$AWS_REGION" 2>/dev/null || true
 
+# Verify the bucket lives in the target region. S3 bucket names are globally
+# unique, so if a previous deploy attempt created this bucket in a different
+# region the 'mb' above silently no-ops. CodeBuild refuses cross-region source
+# downloads and would fail ~18s into the first build (DOWNLOAD_SOURCE phase)
+# with a BucketRegionError. Fail fast here with an actionable message.
+BUCKET_LOCATION=$(aws s3api get-bucket-location --bucket "$BUCKET_NAME" \
+    --query 'LocationConstraint' --output text 2>/dev/null || echo "")
+# us-east-1 reports as 'None' (historical quirk of the S3 API)
+if [ "$BUCKET_LOCATION" = "None" ] || [ -z "$BUCKET_LOCATION" ]; then
+    BUCKET_LOCATION="us-east-1"
+fi
+if [ "$BUCKET_LOCATION" != "$AWS_REGION" ]; then
+    echo ""
+    echo "ERROR: S3 bucket '$BUCKET_NAME' exists in '$BUCKET_LOCATION' but this deploy targets '$AWS_REGION'."
+    echo ""
+    echo "This typically happens after a previous deploy attempt ran against a different region."
+    echo "CodeBuild in '$AWS_REGION' cannot pull sources from a bucket in '$BUCKET_LOCATION'."
+    echo ""
+    echo "Fix: delete the misplaced bucket, then re-run deploy-all.sh:"
+    echo "  aws s3 rm s3://$BUCKET_NAME --recursive --region $BUCKET_LOCATION"
+    echo "  aws s3 rb s3://$BUCKET_NAME --region $BUCKET_LOCATION"
+    echo ""
+    exit 1
+fi
+
 cd cdk && npm install && cd ..
 echo "  done."
 echo ""

--- a/observability/eks-investigation-devops-agent/deploy-all.sh
+++ b/observability/eks-investigation-devops-agent/deploy-all.sh
@@ -101,6 +101,24 @@ echo ""
 
 ECR_REGISTRY="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
 
+# ---------------------------------------------------------------------------
+# CDK bootstrap pre-flight
+# ---------------------------------------------------------------------------
+# The CDK deploy step (~15 min) fails late with a confusing "SSM parameter
+# /cdk-bootstrap/hnb659fds/version not found" error if this account/region has
+# never been bootstrapped. Check upfront so the user sees the fix in seconds.
+if ! aws ssm get-parameter \
+        --name /cdk-bootstrap/hnb659fds/version \
+        --region "$AWS_REGION" >/dev/null 2>&1; then
+    echo ""
+    echo "ERROR: CDK is not bootstrapped in $AWS_REGION for account $AWS_ACCOUNT_ID."
+    echo ""
+    echo "Run this once, then re-run deploy-all.sh:"
+    echo "  npx cdk bootstrap aws://$AWS_ACCOUNT_ID/$AWS_REGION"
+    echo ""
+    exit 1
+fi
+
 # =============================================================================
 # STEP 1: Install CDK dependencies and create S3 bucket for CodeBuild sources
 # =============================================================================

--- a/observability/eks-investigation-devops-agent/deploy-all.sh
+++ b/observability/eks-investigation-devops-agent/deploy-all.sh
@@ -131,10 +131,33 @@ aws s3 mb "s3://$BUCKET_NAME" --region "$AWS_REGION" 2>/dev/null || true
 # region the 'mb' above silently no-ops. CodeBuild refuses cross-region source
 # downloads and would fail ~18s into the first build (DOWNLOAD_SOURCE phase)
 # with a BucketRegionError. Fail fast here with an actionable message.
-BUCKET_LOCATION=$(aws s3api get-bucket-location --bucket "$BUCKET_NAME" \
-    --query 'LocationConstraint' --output text 2>/dev/null || echo "")
+#
+# Also handles the case where 'mb' failed for another reason (e.g., S3 name
+# cooldown after a recent DeleteBucket) so we abort instead of marching into
+# the CDK deploy with a bucket that doesn't exist.
+BUCKET_LOCATION_RAW=$(aws s3api get-bucket-location --bucket "$BUCKET_NAME" \
+    --query 'LocationConstraint' --output text 2>&1)
+BUCKET_LOCATION_EXIT=$?
+
+if [ $BUCKET_LOCATION_EXIT -ne 0 ]; then
+    echo ""
+    echo "ERROR: Could not verify S3 bucket '$BUCKET_NAME'."
+    echo ""
+    echo "  $BUCKET_LOCATION_RAW"
+    echo ""
+    if echo "$BUCKET_LOCATION_RAW" | grep -q "NoSuchBucket"; then
+        echo "The bucket does not exist. 'aws s3 mb' above likely failed silently."
+        echo "A common cause is the S3 name-reuse cooldown after a recent DeleteBucket"
+        echo "(can take several minutes). Wait a bit and re-run deploy-all.sh, or try:"
+        echo "  aws s3 mb s3://$BUCKET_NAME --region $AWS_REGION"
+    fi
+    echo ""
+    exit 1
+fi
+
+BUCKET_LOCATION="$BUCKET_LOCATION_RAW"
 # us-east-1 reports as 'None' (historical quirk of the S3 API)
-if [ "$BUCKET_LOCATION" = "None" ] || [ -z "$BUCKET_LOCATION" ]; then
+if [ "$BUCKET_LOCATION" = "None" ]; then
     BUCKET_LOCATION="us-east-1"
 fi
 if [ "$BUCKET_LOCATION" != "$AWS_REGION" ]; then


### PR DESCRIPTION
## Summary

First-time-user friction fix for the EKS DevOps Agent demo. The deploy currently fails silently or late in three distinct ways when the environment isn't perfectly configured. This PR makes each fail fast with the exact fix.

### Commit 1 — region + CDK bootstrap clarity

- **README Prerequisites:** add `cdk bootstrap` with the one-time command. Without it the deploy fails on the first stack with an opaque `SSM parameter /cdk-bootstrap/hnb659fds/version not found`.
- **README Region callout:** rewrite to cover *both* `AWS_REGION` (CDK stacks) and `DEVOPS_AGENT_REGION` (Agent Space), and flag that `AWS_REGION` silently falls back to `aws configure get region`.
- **README Troubleshooting:** rows for the missing bootstrap SSM parameter and for deploys that targeted the wrong region.
- **`deploy-all.sh` / `deploy-all.ps1`:** pre-flight `aws ssm get-parameter` check before the ~15-minute CDK deploy. If unset, exit with `npx cdk bootstrap aws://<account>/<region>`.

### Commit 2 — S3 bucket region mismatch pre-flight

Follow-up bug I hit after fixing the bootstrap problem. When a prior deploy attempt targets region A, it creates `devops-agent-eks-cfn-templates-<account>` **in A**. S3 bucket names are globally unique, so a later run in region B no-ops the `aws s3 mb` (and the `|| true` hides it). Uploads appear to succeed because the S3 client auto-redirects, but **CodeBuild in B refuses to pull sources from a bucket in A** and fails in DOWNLOAD_SOURCE after ~18 seconds with `BucketRegionError`.

- **`deploy-all.sh` / `deploy-all.ps1`:** after `aws s3 mb`, call `get-bucket-location` and compare against `AWS_REGION`. On mismatch, exit with the exact `rm` + `rb` commands. Handles the us-east-1 `None`/null quirk.
- **README Troubleshooting:** row for the BucketRegionError symptom.

## Motivation

All three gotchas hit me in a single first-run session on a fresh Isengard account. Each failure was actionable *only* after looking at CloudFormation/CodeBuild logs. The fixes are small and preserve existing behavior for correctly-configured environments — the added pre-flight checks are sub-second `aws ssm get-parameter` and `aws s3api get-bucket-location` calls.

## Test plan

- [x] `bash -n deploy-all.sh` — syntax OK
- [x] Verified the bucket-region guard catches the real failure in my reproduction (us-east-1 bucket left behind, eu-west-1 deploy)
- [x] Reviewed full diff — only pre-flight guards and docs; no changes to CDK stacks, Kubernetes manifests, or existing behavior when config is correct
- [ ] (Reviewer) sanity-check `$LASTEXITCODE` and `$BucketLocation`-null handling in PowerShell on a Windows box