### PR TITLE
fix(security/prowler-agent): trigger first scan after image is in ECR

### DIFF
--- a/security/prowler-security-findings-agent/cdk/lib/scanner-stack.ts
+++ b/security/prowler-security-findings-agent/cdk/lib/scanner-stack.ts
@@ -7,7 +7,6 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
-import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
 
 export interface ScannerStackProps extends cdk.StackProps {
@@ -215,56 +214,6 @@ export class ScannerStack extends cdk.Stack {
     this.subnetIds = vpc.publicSubnets.map((s) => s.subnetId);
     this.securityGroupId = securityGroup.securityGroupId;
     this.logGroupName = logGroup.logGroupName;
-
-    // Kick off the first scan as soon as the stack is created. Demos otherwise
-    // open to an empty dashboard until the EventBridge schedule or the user
-    // clicks "Run scan now", which makes the first-time experience feel slow
-    // ("it doesn't work" vs "it's warming up"). Only runs onCreate — never on
-    // update or replace — so re-deploys don't queue extra scans.
-    const firstScan = new AwsCustomResource(this, 'AutoStartFirstScan', {
-      onCreate: {
-        service: 'ECS',
-        action: 'runTask',
-        parameters: {
-          cluster: cluster.clusterArn,
-          taskDefinition: taskDefinition.taskDefinitionArn,
-          launchType: 'FARGATE',
-          platformVersion: 'LATEST',
-          count: 1,
-          networkConfiguration: {
-            awsvpcConfiguration: {
-              subnets: vpc.publicSubnets.map((s) => s.subnetId),
-              securityGroups: [securityGroup.securityGroupId],
-              assignPublicIp: 'ENABLED',
-            },
-          },
-        },
-        physicalResourceId: PhysicalResourceId.of('prowler-first-scan'),
-        // The runTask response body holds taskArn + failures; we don't need to
-        // read any of it back into CFN outputs, so ignore any errors rather
-        // than rolling back the whole stack on a transient ECS hiccup.
-        ignoreErrorCodesMatching: '.*',
-      },
-      policy: AwsCustomResourcePolicy.fromStatements([
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ['ecs:RunTask'],
-          resources: [`${taskDefinition.taskDefinitionArn}`, `${taskDefinition.taskDefinitionArn}:*`],
-        }),
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ['iam:PassRole'],
-          resources: [taskRole.roleArn, taskDefinition.executionRole!.roleArn],
-          conditions: { StringEquals: { 'iam:PassedToService': 'ecs-tasks.amazonaws.com' } },
-        }),
-      ]),
-      // Keep logs short so CW costs stay minimal; the scanner itself logs
-      // anyway.
-      logRetention: logs.RetentionDays.ONE_DAY,
-    });
-    // Wire an explicit dependency on the log group + container so the task
-    // definition is fully ready before we RunTask.
-    firstScan.node.addDependency(taskDefinition);
 
     new cdk.CfnOutput(this, 'EcrRepoUri', {
       value: ecrRepo.repositoryUri,

--- a/security/prowler-security-findings-agent/deploy-all.ps1
+++ b/security/prowler-security-findings-agent/deploy-all.ps1
@@ -161,6 +161,41 @@ aws cognito-idp admin-set-user-password `
     --no-cli-pager *> $null
 End-Step
 
+# Kick off the first scan now — image is in ECR (the CodeBuild step already
+# pushed it), so the Fargate task will pull it cleanly. Doing this here
+# rather than from a CDK custom resource avoids the race where the stack
+# creates faster than CodeBuild publishes :latest.
+$ScannerClusterArn = aws cloudformation describe-stacks `
+    --stack-name "ProwlerSecurityScanner-$AwsRegion" `
+    --query "Stacks[0].Outputs[?OutputKey=='ClusterArn'].OutputValue" --output text
+$ScannerTaskDef = aws cloudformation describe-stacks `
+    --stack-name "ProwlerSecurityScanner-$AwsRegion" `
+    --query "Stacks[0].Outputs[?OutputKey=='TaskDefinitionArn'].OutputValue" --output text
+$ScannerSubnetsCsv = aws cloudformation describe-stacks `
+    --stack-name "ProwlerSecurityScanner-$AwsRegion" `
+    --query "Stacks[0].Outputs[?OutputKey=='ScannerSubnetIds'].OutputValue" --output text
+$ScannerSg = aws cloudformation describe-stacks `
+    --stack-name "ProwlerSecurityScanner-$AwsRegion" `
+    --query "Stacks[0].Outputs[?OutputKey=='ScannerSecurityGroupId'].OutputValue" --output text
+
+Write-Host "Starting first Prowler scan..."
+$SubnetsJson = ($ScannerSubnetsCsv.Split(',') | ForEach-Object { '"' + $_ + '"' }) -join ','
+$NetworkCfg = '{"awsvpcConfiguration":{"subnets":[' + $SubnetsJson + '],"securityGroups":["' + $ScannerSg + '"],"assignPublicIp":"ENABLED"}}'
+aws ecs run-task `
+    --cluster $ScannerClusterArn `
+    --task-definition $ScannerTaskDef `
+    --launch-type FARGATE `
+    --platform-version LATEST `
+    --network-configuration $NetworkCfg `
+    --count 1 `
+    --no-cli-pager --query 'tasks[0].taskArn' --output text *> $null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "  First scan launched."
+} else {
+    Write-Host "  WARN: failed to launch first scan — start it from the dashboard with 'Run scan now'."
+}
+Write-Host ""
+
 $TotalElapsed = (Get-Date) - $DeployStart
 Write-Host ("Total deploy time: {0:mm\:ss}" -f $TotalElapsed)
 Write-Host ""
@@ -177,12 +212,11 @@ Write-Host "  Username: $DemoUsername"
 Write-Host "  Password: $DemoPassword"
 Write-Host "  (Override with `$env:DEMO_USERNAME / `$env:DEMO_PASSWORD before deploy.)"
 Write-Host ""
-Write-Host "Trigger your first scan:"
+Write-Host "First scan is running:"
 Write-Host "  1. Log in to $WebsiteUrl"
-Write-Host "  2. Click 'Run scan now' on the Dashboard"
-Write-Host "  3. Wait ~3-10 min for findings to appear"
-Write-Host "  4. Open any finding and click 'Generate Bedrock Insights' for the"
-Write-Host "     Nova Pro remediation playbook, or 'Investigate with DevOps Agent'"
+Write-Host "  2. Wait ~3-10 min for findings to appear (re-run with 'Run scan now' anytime)"
+Write-Host "  3. Open any finding and click 'Generate Bedrock Insights' for the"
+Write-Host "     Nova Lite 2 remediation playbook, or 'Investigate with DevOps Agent'"
 Write-Host "     to dispatch an autonomous investigation (both are on-demand)."
 Write-Host ""
 if (-not $env:DEVOPS_AGENT_WEBHOOK_URL -or $env:DEVOPS_AGENT_WEBHOOK_URL -eq "") {

--- a/security/prowler-security-findings-agent/deploy-all.sh
+++ b/security/prowler-security-findings-agent/deploy-all.sh
@@ -221,6 +221,41 @@ aws cognito-idp admin-set-user-password \
     --no-cli-pager >/dev/null
 timed_step_done
 
+# Kick off the first scan now — image is in ECR (step 3 already pushed it),
+# so the Fargate task will pull it cleanly. Doing this here instead of from
+# a CDK custom resource at stack-create time avoids the race where the
+# stack creates faster than CodeBuild publishes :latest.
+SCANNER_CLUSTER_ARN=$(aws cloudformation describe-stacks \
+    --stack-name "ProwlerSecurityScanner-$AWS_REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='ClusterArn'].OutputValue" --output text)
+SCANNER_TASK_DEF=$(aws cloudformation describe-stacks \
+    --stack-name "ProwlerSecurityScanner-$AWS_REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='TaskDefinitionArn'].OutputValue" --output text)
+SCANNER_SUBNETS=$(aws cloudformation describe-stacks \
+    --stack-name "ProwlerSecurityScanner-$AWS_REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='ScannerSubnetIds'].OutputValue" --output text)
+SCANNER_SG=$(aws cloudformation describe-stacks \
+    --stack-name "ProwlerSecurityScanner-$AWS_REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='ScannerSecurityGroupId'].OutputValue" --output text)
+
+echo "Starting first Prowler scan..."
+NETWORK_CFG=$(printf '{"awsvpcConfiguration":{"subnets":[%s],"securityGroups":["%s"],"assignPublicIp":"ENABLED"}}' \
+    "$(echo "$SCANNER_SUBNETS" | awk -F, '{for(i=1;i<=NF;i++) printf (i>1?",":"") "\"" $i "\""}')" \
+    "$SCANNER_SG")
+if aws ecs run-task \
+    --cluster "$SCANNER_CLUSTER_ARN" \
+    --task-definition "$SCANNER_TASK_DEF" \
+    --launch-type FARGATE \
+    --platform-version LATEST \
+    --network-configuration "$NETWORK_CFG" \
+    --count 1 \
+    --no-cli-pager --query 'tasks[0].taskArn' --output text >/dev/null 2>&1; then
+    echo "  First scan launched."
+else
+    echo "  WARN: failed to launch first scan — start it from the dashboard with 'Run scan now'."
+fi
+echo ""
+
 DEPLOY_TOTAL=$(( $(date +%s) - DEPLOY_START ))
 printf "Total deploy time: %dm %02ds\n\n" $((DEPLOY_TOTAL/60)) $((DEPLOY_TOTAL%60))
 
@@ -236,11 +271,10 @@ echo "  Username: $DEMO_USERNAME"
 echo "  Password: $DEMO_PASSWORD"
 echo "  (Override with DEMO_USERNAME / DEMO_PASSWORD env vars before deploy.)"
 echo ""
-echo "Trigger your first scan:"
+echo "First scan is running:"
 echo "  1. Log in to $WEBSITE_URL"
-echo "  2. Click 'Run scan now' on the Dashboard"
-echo "  3. Wait ~3-10 min for findings to appear"
-echo "  4. Open any finding and click 'Generate Bedrock Insights' for the"
+echo "  2. Wait ~3-10 min for findings to appear (re-run with 'Run scan now' anytime)"
+echo "  3. Open any finding and click 'Generate Bedrock Insights' for the"
 echo "     Nova Lite 2 remediation playbook, or 'Investigate with DevOps Agent'"
 echo "     to dispatch an autonomous investigation (both are on-demand)."
 echo ""


### PR DESCRIPTION
## Summary

The Prowler scan that auto-starts on first deploy was racing CodeBuild and failing on Fargate with `CannotPullContainerError: ... prowler-security-scanner:latest: not found`.

**Root cause** — `cdk/lib/scanner-stack.ts` defined an `AwsCustomResource` (`AutoStartFirstScan`) that called `ECS.RunTask` at stack-create time. The scanner stack is created in step 2 of `deploy-all.sh`, but the Prowler image isn't published to ECR until step 3 (`scripts/build-scanner-image.sh` waits for CodeBuild). Fargate therefore tried to pull `:latest` before it existed.

**Fix** — drop the CDK custom resource and move the first-scan kick-off to the tail of `deploy-all.sh` / `deploy-all.ps1`, after the CodeBuild step has published the image. The same `aws ecs run-task` call now happens with the image guaranteed to be in ECR.

## Changes

- `cdk/lib/scanner-stack.ts` — remove `AutoStartFirstScan` custom resource and the now-unused `AwsCustomResource` / `AwsCustomResourcePolicy` / `PhysicalResourceId` imports.
- `deploy-all.sh` — add a final block that reads `ScannerStack` outputs (cluster ARN, task definition, subnets, security group) and runs one Fargate task. Update the closing message from "Click Run scan now" to "First scan is running".
- `deploy-all.ps1` — equivalent PowerShell.

## Test plan

- [x] `tsc --noEmit` clean for `cdk/`
- [x] `bash -n deploy-all.sh` clean
- [x] `cdk synth ProwlerSecurityScanner-<region>` no longer contains `AutoStartFirstScan` / `prowler-first-scan` in the generated template
- [x] End-to-end: fresh deploy in a clean account/region — scanner image is in ECR before first `RunTask` fires; dashboard opens with a scan in flight, no `CannotPullContainerError` in ECS task history