### PR TITLE
fix(mcp-server): Rename package to avoid PyPI typosquat collision

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/README.md
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/README.md
@@ -31,7 +31,7 @@ Click on the relevant below badge to automatically add this IDE MCP server to yo
 
 | Kiro | Cursor | VS Code |
 |:----:|:------:|:-------:|
-| [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=genai-cost-optimizer&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-cost-optim-genai%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%22scan_project%22%2C%22analyze_file%22%5D%7D) | [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/en/install-mcp?name=genai-cost-optimizer&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3AtY29zdC1vcHRpbS1nZW5haSJdLCJlbnYiOnsiRkFTVE1DUF9MT0dfTEVWRUwiOiJFUlJPUiJ9LCJkaXNhYmxlZCI6ZmFsc2UsImF1dG9BcHByb3ZlIjpbInNjYW5fcHJvamVjdCIsImFuYWx5emVfZmlsZSJdfQ%3D%3D) | [![Install on VS Code](https://img.shields.io/badge/Install_on-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=GenAI%20Cost%20Optimizer&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-cost-optim-genai%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%22scan_project%22%2C%22analyze_file%22%5D%7D) |
+| [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=genai-cost-optimizer&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22--from%22%2C%22.%22%2C%22awslabs-genai-cost-optim-mcp-server%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%22scan_project%22%2C%22analyze_file%22%5D%7D) | [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/en/install-mcp?name=genai-cost-optimizer&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyItLWZyb20iLCIuIiwiYXdzbGFicy1nZW5haS1jb3N0LW9wdGltLW1jcC1zZXJ2ZXIiXSwiZW52Ijp7IkZBU1RNQ1BfTE9HX0xFVkVMIjoiRVJST1IifSwiZGlzYWJsZWQiOmZhbHNlLCJhdXRvQXBwcm92ZSI6WyJzY2FuX3Byb2plY3QiLCJhbmFseXplX2ZpbGUiXX0=) | [![Install on VS Code](https://img.shields.io/badge/Install_on-VS_Code-FF9900?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=GenAI%20Cost%20Optimizer&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22--from%22%2C%22.%22%2C%22awslabs-genai-cost-optim-mcp-server%22%5D%2C%22env%22%3A%7B%22FASTMCP_LOG_LEVEL%22%3A%22ERROR%22%7D%2C%22disabled%22%3Afalse%2C%22autoApprove%22%3A%5B%22scan_project%22%2C%22analyze_file%22%5D%7D) |
 
 Or manually configure the MCP server in your MCP client configuration:
 
@@ -40,7 +40,7 @@ Or manually configure the MCP server in your MCP client configuration:
   "mcpServers": {
     "genai-cost-optimizer": {
       "command": "uvx",
-      "args": ["mcp-cost-optim-genai"],
+      "args": ["--from", ".", "awslabs-genai-cost-optim-mcp-server"],
       "env": {
         "FASTMCP_LOG_LEVEL": "ERROR"
       },
@@ -305,7 +305,7 @@ This scanner works alongside **AWS MCP Servers** for complete cost analysis:
 {
   "mcpServers": {
     "genai-cost-optimizer": {
-      "command": "mcp-cost-optim-genai",
+      "command": "awslabs-genai-cost-optim-mcp-server",
       "disabled": false
     },
     "aws-mcp": {
@@ -420,7 +420,7 @@ The scanner correctly detects LangChain Bedrock usage (`ChatBedrockConverse`, `C
 ## Project Structure
 
 ```
-mcp-cost-optim-genai/
+awslabs-genai-cost-optim-mcp-server/
 ├── src/mcp_cost_optim_genai/     # Main package
 │   ├── server.py                 # FastMCP server entry point
 │   ├── scanner.py                # Project scanning logic

--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/power/mcp.json
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/power/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "genai-cost-optimizer": {
       "command": "uvx",
-      "args": ["mcp-cost-optim-genai"],
+      "args": ["--from", ".", "awslabs-genai-cost-optim-mcp-server"],
       "disabled": false,
       "autoApprove": [
         "scan_project",

--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/pyproject.toml
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "mcp-cost-optim-genai"
+name = "awslabs-genai-cost-optim-mcp-server"
 version = "0.1.0"
 description = "MCP server for AWS GenAI cost optimization insights"
 readme = "README.md"
@@ -26,7 +26,7 @@ dev = [
 ]
 
 [project.scripts]
-mcp-cost-optim-genai = "mcp_cost_optim_genai.server:main"
+awslabs-genai-cost-optim-mcp-server = "mcp_cost_optim_genai.server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcp_cost_optim_genai"]


### PR DESCRIPTION
## Summary
Rename from `mcp-cost-optim-genai` to `awslabs-genai-cost-optim-mcp-server` to avoid collision with squatted PyPI package.

## Changes
- `pyproject.toml`: Updated package name and script entry point
- `power/mcp.json`: Use `--from . <name>` pattern for local invocation
- `README.md`: Updated badges, manual config examples, and project structure reference

## Why
Anyone running `uvx mcp-cost-optim-genai` gets an empty Poneglyph stub from PyPI instead of this code. The new name follows the awslabs convention (e.g., `awslabs.aws-pricing-mcp-server`).

Closes #25