### PR TITLE
fix(mcp-server): Fix unreachable dead code branch in prompt routing detection

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
@@ -1243,8 +1243,13 @@ response = agent(query)''',
         if complexity_findings:
             findings.extend(complexity_findings)
         
-        # Opportunity 3: Premium/ultra-premium tier usage
-        if premium_models and not models_by_family:
+        # Opportunity 3: Premium/ultra-premium tier with single model but mixed complexity prompts
+        # Only trigger if no multi-model opportunity was already found (Opportunity 1)
+        has_multi_model_opportunity = any(
+            len(set(m['model_id'] for m in models)) > 1
+            for models in models_by_family.values()
+        )
+        if premium_models and not has_multi_model_opportunity:
             # Using premium models but no multiple models detected
             # Suggest routing if there's complexity variation
             for model_info in premium_models:


### PR DESCRIPTION
## Summary
Fix the unreachable `premium_tier_with_mixed_complexity` branch in `_detect_prompt_routing`.

## Problem
The condition `if premium_models and not models_by_family` was always False because both variables are populated from the same loop over `model_findings`.

## Fix
Replace with `if premium_models and not has_multi_model_opportunity` — triggers when premium models are used but no multi-model routing opportunity was already detected (Opportunity 1).

Closes #35