### PR TITLE
fix(mcp-server): Avoid wasteful re-detection in cross-region antipattern check

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
@@ -218,7 +218,7 @@ class BedrockDetector(BaseDetector):
         findings.extend(nova_caching_findings)
 
         # Detect caching with cross-region inference anti-pattern
-        cross_region_findings = self._detect_caching_cross_region_antipattern(content, file_path)
+        cross_region_findings = self._detect_caching_cross_region_antipattern(content, file_path, model_findings)
         findings.extend(cross_region_findings)
         
         # Detect dynamic variables in system prompts
@@ -784,7 +784,7 @@ class BedrockDetector(BaseDetector):
         
         return findings
 
-    def _detect_caching_cross_region_antipattern(self, content: str, file_path: str) -> List[Dict[str, Any]]:
+    def _detect_caching_cross_region_antipattern(self, content: str, file_path: str, existing_model_findings: List[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Detect prompt caching used with cross-region inference profiles.
         
         Uses the generic model detection to find cross-region model IDs,
@@ -792,6 +792,11 @@ class BedrockDetector(BaseDetector):
         
         Static prompts + cross-region + caching = OK (same cache across regions)
         Dynamic prompts + cross-region + caching = RISK (different cache per request)
+        
+        Args:
+            content: File content
+            file_path: Path to file
+            existing_model_findings: Pre-computed model findings from analyze() to avoid re-detection
         """
         findings = []
         
@@ -806,8 +811,11 @@ class BedrockDetector(BaseDetector):
         # Analyze if prompts are static or dynamic
         prompt_analysis = self._analyze_prompt_staticness(content)
         
-        # Use generic model detection to find ALL models with region prefixes
-        model_findings = self._detect_models(content, file_path)
+        # Use pre-computed model findings if available, otherwise detect (for standalone calls)
+        if existing_model_findings is not None:
+            model_findings = existing_model_findings
+        else:
+            model_findings = self._detect_models(content, file_path)
         
         for model_finding in model_findings:
             parsed = model_finding.get("parsed", {})


### PR DESCRIPTION
## Summary
Pass pre-computed model findings to `_detect_caching_cross_region_antipattern` instead of re-running detection.

## Problem
`analyze()` already calls `_detect_models()` and stores results. The cross-region detector was calling it again — a full second regex pass over the same content with the same results.

## Changes
- Add `existing_model_findings` parameter to `_detect_caching_cross_region_antipattern`
- Pass `model_findings` from `analyze()` to avoid redundant work
- Fallback to self-detection if called standalone (backward compatible)

Closes #37