### PR TITLE
fix(mcp-server): Add import-aware check for legacy Bedrock pattern

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
@@ -38,7 +38,7 @@ class BedrockDetector(BaseDetector):
         "ChatBedrockConverse": r"ChatBedrockConverse\s*\(",
         "ChatBedrock": r"ChatBedrock\s*\(",
         "BedrockLLM": r"BedrockLLM\s*\(",
-        "Bedrock": r"Bedrock\s*\(",  # Legacy LangChain class
+        "Bedrock": r"(?<!\w)Bedrock\s*\(",  # Legacy LangChain class — word boundary to avoid matching unrelated classes
     }
 
     def can_analyze(self, file_path: Path) -> bool:
@@ -558,7 +558,17 @@ class BedrockDetector(BaseDetector):
         """Detect Bedrock API call patterns."""
         findings = []
 
+        # Check if file has LangChain Bedrock imports (needed for legacy "Bedrock" pattern)
+        has_langchain_bedrock_import = bool(re.search(
+            r'from\s+langchain.*import.*Bedrock|from\s+langchain_aws.*import.*Bedrock',
+            content
+        ))
+
         for call_type, pattern in self.INVOKE_PATTERNS.items():
+            # Skip legacy "Bedrock" pattern if no LangChain import is present
+            if call_type == "Bedrock" and not has_langchain_bedrock_import:
+                continue
+
             matches = re.finditer(pattern, content)
             for match in matches:
                 line_num = content[:match.start()].count('\n') + 1


### PR DESCRIPTION
## Summary
Add import-aware check for the legacy Bedrock( pattern to reduce false positives.

## Problem
The bare Bedrock( regex matched any class named Bedrock. Any imported Bedrock class — even unrelated AWS SDK types or custom helpers — counted as a Bedrock API call.

## Changes
- Add word-boundary lookbehind to the regex pattern
- Only match legacy Bedrock( when a LangChain Bedrock import is present in the file

Closes #41