### PR TITLE
fix(mcp-server): Make test file/directory exclusion configurable

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/scan_config.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/scan_config.py
@@ -16,7 +16,7 @@ DEFAULT_SKIP_DIRS = {
     "bower_components", "jspm_packages",
     
     # Build outputs
-    "dist", "build", "out", "target", "bin", "obj",
+    "out", "target", "bin", "obj",
     ".next", ".nuxt", ".output", ".vercel", ".netlify",
     
     # CDK/Terraform
@@ -37,8 +37,10 @@ DEFAULT_SKIP_DIRS = {
     
     # Documentation builds
     "docs/_build", "site", "_site",
-    
-    # Test directories
+}
+
+# Test directories — excluded by default but configurable via include_tests parameter
+TEST_SKIP_DIRS = {
     "tests", "test", "__tests__", "spec", "specs",
 }
 
@@ -94,12 +96,13 @@ def should_skip_directory(dir_path: Path, skip_dirs: Set[str] = None) -> bool:
     return False
 
 
-def should_scan_file(file_path: Path, max_size: int = MAX_FILE_SIZE) -> bool:
+def should_scan_file(file_path: Path, max_size: int = MAX_FILE_SIZE, include_tests: bool = False) -> bool:
     """Check if a file should be scanned.
     
     Args:
         file_path: File path to check
         max_size: Maximum file size in bytes
+        include_tests: If True, don't skip test files (test_*.py, test-*.py)
         
     Returns:
         True if file should be scanned
@@ -112,10 +115,11 @@ def should_scan_file(file_path: Path, max_size: int = MAX_FILE_SIZE) -> bool:
     if file_path.suffix not in SCANNABLE_EXTENSIONS:
         return False
     
-    # Skip test files (test-*.* or test_*.*)
-    file_name = file_path.name.lower()
-    if file_name.startswith("test-") or file_name.startswith("test_"):
-        return False
+    # Skip test files (test-*.* or test_*.*) unless include_tests is set
+    if not include_tests:
+        file_name = file_path.name.lower()
+        if file_name.startswith("test-") or file_name.startswith("test_"):
+            return False
     
     # Skip compiled JavaScript files when TypeScript source exists
     # Example: skip "runtime-stack.js" if "runtime-stack.ts" exists
@@ -164,7 +168,8 @@ def should_scan_file(file_path: Path, max_size: int = MAX_FILE_SIZE) -> bool:
 def find_scannable_files(
     project_path: Path,
     skip_dirs: Set[str] = None,
-    max_files: int = None
+    max_files: int = None,
+    include_tests: bool = False
 ) -> List[Path]:
     """Find all scannable files in a project using smart filtering.
     
@@ -175,12 +180,17 @@ def find_scannable_files(
         project_path: Root directory to scan
         skip_dirs: Custom set of directory names to skip
         max_files: Maximum number of files to return (None for unlimited)
+        include_tests: If True, include test directories and test files
         
     Returns:
         List of file paths to scan
     """
     if skip_dirs is None:
-        skip_dirs = DEFAULT_SKIP_DIRS
+        skip_dirs = DEFAULT_SKIP_DIRS.copy()
+    
+    # Add test directories to skip unless include_tests is set
+    if not include_tests:
+        skip_dirs = skip_dirs | TEST_SKIP_DIRS
     
     scannable_files = []
     
@@ -198,7 +208,7 @@ def find_scannable_files(
         for file_name in files:
             file_path = root_path / file_name
             
-            if should_scan_file(file_path):
+            if should_scan_file(file_path, include_tests=include_tests):
                 scannable_files.append(file_path)
                 
                 # Stop if we've hit the max

--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/scanner.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/scanner.py
@@ -13,6 +13,7 @@ from .scan_config import (
     find_scannable_files,
     estimate_scan_size,
     DEFAULT_SKIP_DIRS,
+    TEST_SKIP_DIRS,
 )
 from .utils import add_file_links_to_findings
 from .presentation_guidelines import PRESENTATION_GUIDELINES
@@ -34,7 +35,8 @@ class ProjectScanner:
         project_path: str,
         skip_dirs: Optional[Set[str]] = None,
         max_files: Optional[int] = None,
-        estimate_only: bool = False
+        estimate_only: bool = False,
+        include_tests: bool = False
     ) -> str:
         """Scan entire project directory with smart filtering.
         
@@ -43,6 +45,7 @@ class ProjectScanner:
             skip_dirs: Additional directories to skip (merged with defaults)
             max_files: Maximum number of files to scan (safety limit)
             estimate_only: If True, only return scan size estimate without scanning
+            include_tests: If True, include test directories and test files
             
         Returns:
             JSON string with scan results and findings
@@ -81,7 +84,7 @@ class ProjectScanner:
             scan_warning = None
 
         # Find all scannable files efficiently
-        scannable_files = find_scannable_files(path, effective_skip_dirs, max_files)
+        scannable_files = find_scannable_files(path, effective_skip_dirs, max_files, include_tests=include_tests)
         
         findings = []
         files_scanned = 0

--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/server.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/server.py
@@ -23,7 +23,8 @@ async def scan_project(
     path: str,
     skip_dirs: str = "",
     max_files: int = 0,
-    estimate_only: bool = False
+    estimate_only: bool = False,
+    include_tests: bool = False
 ) -> str:
     """Scan a project directory for AWS GenAI service usage patterns.
     
@@ -38,6 +39,8 @@ async def scan_project(
                   safety limit for very large projects.
         estimate_only: If true, only return scan size estimate without actually scanning.
                       Useful for checking if a scan will be too large.
+        include_tests: If true, include test directories and test files in the scan.
+                      Useful for CDK/IaC projects where test dirs contain production code.
         
     Returns:
         JSON string with scan results and findings.
@@ -56,6 +59,9 @@ async def scan_project(
         
         # Skip additional custom directories
         scan_project("/path/to/project", skip_dirs="data,models,checkpoints")
+        
+        # Include test directories (useful for CDK projects)
+        scan_project("/path/to/project", include_tests=True)
     """
     global _latest_scan
     scanner = ProjectScanner()
@@ -72,7 +78,8 @@ async def scan_project(
         path,
         skip_dirs=custom_skip_dirs,
         max_files=max_files_param,
-        estimate_only=estimate_only
+        estimate_only=estimate_only,
+        include_tests=include_tests
     )
     
     if not estimate_only:


### PR DESCRIPTION
## Summary
Add `include_tests` parameter so CDK/IaC projects can scan test directories.

## Problem
Test directories and files were always skipped with no override. CDK projects often put production constructs in test-named directories.

## Changes
- Separate TEST_SKIP_DIRS from DEFAULT_SKIP_DIRS
- Add `include_tests` parameter to `scan_project` tool, `find_scannable_files`, and `should_scan_file`
- Fix duplicate entries (dist, build) in DEFAULT_SKIP_DIRS

Closes #45