### PR TITLE
fix(mcp-server): Expand BedrockDetector to analyze YAML, JSON, Terraform files

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
@@ -42,8 +42,8 @@ class BedrockDetector(BaseDetector):
     }
 
     def can_analyze(self, file_path: Path) -> bool:
-        """Check if file is Python or TypeScript/JavaScript."""
-        return file_path.suffix in [".py", ".ts", ".js", ".tsx", ".jsx"]
+        """Check if file type is supported for Bedrock pattern detection."""
+        return file_path.suffix in [".py", ".ts", ".js", ".tsx", ".jsx", ".yaml", ".yml", ".json", ".tf", ".tfvars"]
     
     def _parse_model_id(self, model_id: str) -> Dict[str, Any]:
         """Parse a Bedrock model ID into structured components.


### PR DESCRIPTION
## Summary
Expand BedrockDetector.can_analyze to include YAML, JSON, and Terraform files.

## Problem
Scanner reads .yaml, .yml, .json, .tf, .tfvars files but BedrockDetector only analyzed .py/.ts/.js. Model IDs in CDK YAML or Terraform variables were silently discarded.

## Changes
- Add .yaml, .yml, .json, .tf, .tfvars to can_analyze supported extensions

Closes #47