### PR TITLE
fix(mcp-server): Filter false positives in cache detection

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/bedrock_detector.py
@@ -797,8 +797,19 @@ class BedrockDetector(BaseDetector):
         
         # Check if caching is enabled in this file
         # Support both snake_case (Python) and camelCase (TypeScript/JavaScript)
-        has_cache_point = bool(re.search(r'cachePoint', content))
-        has_cache_control = bool(re.search(r'cache(?:_control|Control)', content))  # Matches cache_control or cacheControl
+        # Use finditer to check context and filter false positives (comments, docstrings)
+        cache_point_matches = list(re.finditer(r'cachePoint', content))
+        cache_control_matches = list(re.finditer(r'cache(?:_control|Control)', content))
+        
+        # Filter out matches in comments/docstrings
+        has_cache_point = any(
+            not self._is_likely_false_positive(content, m.start(), m.end())
+            for m in cache_point_matches
+        )
+        has_cache_control = any(
+            not self._is_likely_false_positive(content, m.start(), m.end())
+            for m in cache_control_matches
+        )
         
         if not (has_cache_point or has_cache_control):
             return findings  # No caching, no anti-pattern


### PR DESCRIPTION
## Summary
Apply false-positive filtering to cachePoint/cache_control detection.

## Problem
Bare substring search triggered on comments, docstrings, HTTP header constants, and unrelated imports.

## Changes
- Use finditer + _is_likely_false_positive filter (same as model ID detection)
- Only trigger cross-region warnings when cache references are in actual code

Closes #49