### PR TITLE
fix(mcp-server): Only detect session usage when AgentCore import is present

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/agentcore_detector.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/detectors/agentcore_detector.py
@@ -195,8 +195,19 @@ class AgentCoreDetector(BaseDetector):
         return findings
 
     def _detect_session_usage(self, content: str, file_path: str) -> List[Dict[str, Any]]:
-        """Detect session management usage."""
+        """Detect session management usage.
+        
+        Only reports if AgentCore-specific imports/patterns are present in the file
+        to avoid false positives from generic RequestContext usage in web frameworks.
+        """
         findings = []
+
+        # Only detect session patterns if AgentCore is present in the file
+        has_agentcore = self._has_agentcore_app(content) or bool(
+            re.search(r'from\s+bedrock_agentcore|import\s+bedrock_agentcore', content)
+        )
+        if not has_agentcore:
+            return findings
 
         for pattern in self.SESSION_PATTERNS:
             matches = re.finditer(pattern, content)


### PR DESCRIPTION
## Summary
Reduce false positives from RequestContext detection.

## Problem
RequestContext is a generic name in many web frameworks. Any file using it was flagged as having AgentCore session management.

## Changes
- Only report session patterns when bedrock_agentcore import or app initialization is found in the file

Closes #57