### PR TITLE
fix(mcp-server): Use importlib.metadata for __version__

### DIFF
--- a/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/__init__.py
+++ b/cost-optimization/aws-genai-cost-optimization-mcp-server/src/mcp_cost_optim_genai/__init__.py
@@ -1,3 +1,9 @@
 """AWS GenAI Cost Optimization MCP Server."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("awslabs-genai-cost-optim-mcp-server")
+except PackageNotFoundError:
+    # Package not installed (e.g., running from source)
+    __version__ = "0.1.0-dev"


### PR DESCRIPTION
## Summary
Single source of truth for package version.

## Problem
__init__.py and pyproject.toml both hardcoded version 0.1.0 independently — they would drift.

## Changes
- Read version from package metadata via importlib.metadata
- Fallback to '0.1.0-dev' when running from source

Closes #60