### PR TITLE
fix: structure-check workflow fails on multi-line GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -16,8 +16,12 @@ jobs:
         id: detect
         run: |
           DEMOS=$(git diff --name-only origin/main...HEAD | grep -oP '^[^/]+/[^/]+' | sort -u | grep -v '^\.' | grep -v '^shared' | grep -v '^docs' || true)
-          echo "demos=$DEMOS" >> $GITHUB_OUTPUT
           echo "Modified demos: $DEMOS"
+          # Use delimiter syntax for multi-line output values
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "demos<<$EOF" >> $GITHUB_OUTPUT
+          echo "$DEMOS" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Check demo structure
         run: |


### PR DESCRIPTION
Fixes the structure-check workflow failing with: Unable to process file command output successfully - Invalid format. When a PR touches multiple demos, git diff returns multiple paths. Writing these to GITHUB_OUTPUT with echo demos=DEMOS fails because GitHub Actions interprets each subsequent line as a new malformed output command. Fix uses heredoc delimiter syntax for multi-line output values. Reported in PR #74.