### PR TITLE
feat: add .no-deploy exemption for local tools and MCP servers

### DIFF
--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Check demo structure
         run: |
           EXIT_CODE=0
+          HAS_EXEMPT=""
           DEMOS="${{ steps.detect.outputs.demos }}"
 
           if [ -z "$DEMOS" ]; then
@@ -61,19 +62,25 @@ jobs:
               echo "✅ ARCHITECTURE.md exists"
             fi
 
-            # Check deploy scripts
-            if ! ls "$DEMO"/*.ps1 1>/dev/null 2>&1 && ! ls "$DEMO"/scripts/*.ps1 1>/dev/null 2>&1; then
-              echo "❌ Missing PowerShell deployment script (.ps1)"
-              EXIT_CODE=1
+            # Check deploy scripts (skip if .no-deploy marker exists)
+            if [ -f "$DEMO/.no-deploy" ]; then
+              echo "ℹ️  .no-deploy marker found — deployment scripts not required"
+              echo "   Reason: $(cat "$DEMO/.no-deploy")"
+              HAS_EXEMPT="true"
             else
-              echo "✅ PowerShell script exists"
-            fi
+              if ! ls "$DEMO"/*.ps1 1>/dev/null 2>&1 && ! ls "$DEMO"/scripts/*.ps1 1>/dev/null 2>&1; then
+                echo "❌ Missing PowerShell deployment script (.ps1)"
+                EXIT_CODE=1
+              else
+                echo "✅ PowerShell script exists"
+              fi
 
-            if ! ls "$DEMO"/*.sh 1>/dev/null 2>&1 && ! ls "$DEMO"/scripts/*.sh 1>/dev/null 2>&1; then
-              echo "❌ Missing Bash deployment script (.sh)"
-              EXIT_CODE=1
-            else
-              echo "✅ Bash script exists"
+              if ! ls "$DEMO"/*.sh 1>/dev/null 2>&1 && ! ls "$DEMO"/scripts/*.sh 1>/dev/null 2>&1; then
+                echo "❌ Missing Bash deployment script (.sh)"
+                EXIT_CODE=1
+              else
+                echo "✅ Bash script exists"
+              fi
             fi
 
             # Check for solution adoption tracking in CDK app file
@@ -107,3 +114,43 @@ jobs:
           done
 
           exit $EXIT_CODE
+
+      - name: Label deploy-exempt PRs
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Check if any demo used .no-deploy by looking at the step output
+            const output = `${{ steps.detect.outputs.demos }}`;
+            const fs = require('fs');
+            const demos = output.trim().split('\n').filter(Boolean);
+            const exemptDemos = [];
+            for (const demo of demos) {
+              try {
+                fs.accessSync(`${demo}/.no-deploy`);
+                exemptDemos.push(demo);
+              } catch {}
+            }
+            if (exemptDemos.length > 0) {
+              const demoList = exemptDemos.map(d => `- \`${d}\``).join('\n');
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  labels: ['deploy-exempt']
+                });
+              } catch (e) {
+                core.warning(`Could not add label: ${e.message}`);
+              }
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `## ℹ️ Deploy-Exempt Demos\n\nThe following demos use a \`.no-deploy\` marker (no deployment scripts required):\n\n${demoList}\n\nPlease verify the exemption is appropriate during review.`
+                });
+              } catch (e) {
+                core.warning(`Could not post comment: ${e.message}`);
+              }
+            }

--- a/.kiro/steering/contributor-guide.md
+++ b/.kiro/steering/contributor-guide.md
@@ -109,6 +109,21 @@ sample-genai-ops-demos/
 5. Solution adoption tracking in CDK app file
 6. `.gitignore` including `cdk.out*`
 
+### Deploy Script Exemption (`.no-deploy`)
+
+Demos that are local tools with no AWS infrastructure to deploy may opt out of deployment scripts by placing a `.no-deploy` file at the demo root. The file must contain a one-line explanation of why scripts aren't needed.
+
+**Valid use cases:**
+- MCP servers installed via `uvx` or `pip`
+- Local CLI tools that don't deploy AWS resources
+- Kiro Powers with no cloud infrastructure
+
+**Not valid for:**
+- Demos that deploy CDK/CloudFormation resources (these always need scripts)
+- Demos with AWS infrastructure of any kind
+
+The CI workflow will flag PRs using `.no-deploy` with a `deploy-exempt` label for maintainer review. All other required files (README, ARCHITECTURE, tracking) still apply.
+
 ---
 
 ## Implementation Patterns


### PR DESCRIPTION
Demos that don't deploy AWS infrastructure (MCP servers, CLI tools, Kiro Powers) can opt out of deployment script checks by placing a .no-deploy marker at the demo root. ## Changes - **structure-check.yml**: Skip .ps1/.sh check if .no-deploy exists; add deploy-exempt label + comment (best-effort on fork PRs) - **contributor-guide.md**: Document valid use cases and limitations for the exemption ## How it works 1. Contributor adds a .no-deploy file with a one-line reason 2. CI skips the deployment script check for that demo 3. PR gets labeled deploy-exempt for maintainer visibility 4. All other checks (README, ARCHITECTURE, tracking, naming) still apply ## Valid use cases - MCP servers installed via uvx or pip - Local CLI tools with no AWS resources - Kiro Powers with no cloud infrastructure ## Context Needed because pre-governance demos like ai-chaos-engineering-with-fis and aws-genai-cost-optimization-mcp-server are local MCP servers with no infrastructure to deploy. Reported in PR #74.