### PR TITLE
fix(eks-demo): pin Kubernetes version to standard support and stop silent extended-support billing

### DIFF
--- a/observability/eks-investigation-devops-agent/README.md
+++ b/observability/eks-investigation-devops-agent/README.md
@@ -47,7 +47,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full architecture docum
 ## Prerequisites
 
 - **AWS CLI v2.34.21+** with configured credentials and default region
-- kubectl v1.31+
+- kubectl v1.36+
 - Node.js 20+ with npm
 - `zip` utility
 - Git
@@ -268,7 +268,7 @@ All stack IDs include the region suffix for multi-region deployment support.
 | Stack | Purpose | Key Resources |
 |-------|---------|---------------|
 | `DevOpsAgentEksNetwork-{region}` | Networking | VPC, 2 AZs, public + private + data subnets, NAT gateway |
-| `DevOpsAgentEksCompute-{region}` | Compute | EKS cluster (K8s 1.33), managed node group (Graviton), IRSA |
+| `DevOpsAgentEksCompute-{region}` | Compute | EKS cluster (K8s 1.36, override with `EKS_KUBERNETES_VERSION`), managed node group (Graviton), IRSA |
 | `DevOpsAgentEksPipeline-{region}` | CI/CD | 3 CodeBuild projects, 3 ECR repositories |
 | `DevOpsAgentEksDatabase-{region}` | Data | RDS PostgreSQL 15 (db.t3.micro, encrypted), Secrets Manager |
 | `DevOpsAgentEksAuth-{region}` | Auth | Cognito User Pool with custom attributes |

--- a/observability/eks-investigation-devops-agent/cdk/bin/app.ts
+++ b/observability/eks-investigation-devops-agent/cdk/bin/app.ts
@@ -43,6 +43,10 @@ const projectName = app.node.tryGetContext('projectName') ?? 'devops-agent-eks';
 const eksNodeArchitecture = app.node.tryGetContext('eksNodeArchitecture') ?? 'arm64';
 const eksNodeInstanceType = app.node.tryGetContext('eksNodeInstanceType') ?? 't4g.medium';
 const eksNodeDesiredCapacity = Number(app.node.tryGetContext('eksNodeDesiredCapacity') ?? '2');
+// Newest supported release, correct for a new cluster. Upgrading an existing
+// cluster moves one minor version at a time, so override and step through.
+// Keep the kubectl layer in failure-simulator-api-stack.ts in step with this.
+const eksKubernetesVersion = app.node.tryGetContext('eksKubernetesVersion') ?? '1.36';
 const devOpsAgentWebhookUrl = app.node.tryGetContext('devOpsAgentWebhookUrl') ?? '';
 const devOpsAgentWebhookSecret = app.node.tryGetContext('devOpsAgentWebhookSecret') ?? '';
 const apiGatewayEndpoint = app.node.tryGetContext('apiGatewayEndpoint') ?? '';
@@ -89,6 +93,7 @@ const computeStack = new ComputeStack(app, `DevOpsAgentEksCompute-${region}`, {
   nodeInstanceType: eksNodeInstanceType,
   nodeArchitecture: eksNodeArchitecture,
   nodeDesiredCapacity: eksNodeDesiredCapacity,
+  kubernetesVersion: eksKubernetesVersion,
   description: 'DevOps Agent EKS Demo Compute Stack',
 });
 

--- a/observability/eks-investigation-devops-agent/cdk/lambda/failure-simulator-api/index.py
+++ b/observability/eks-investigation-devops-agent/cdk/lambda/failure-simulator-api/index.py
@@ -90,7 +90,7 @@ def _check_and_auto_revert():
 
     return reverted
 
-# Binary paths from the kubectl Lambda layer (@aws-cdk/lambda-layer-kubectl-v31).
+# Binary paths from the kubectl Lambda layer (@aws-cdk/lambda-layer-kubectl-v36).
 # This layer provides kubectl and helm — do NOT install these tools separately.
 # See failure-simulator-api-stack.ts for the layer configuration.
 # NOTE: aws CLI is NOT included in this layer. Use boto3 for AWS API calls.

--- a/observability/eks-investigation-devops-agent/cdk/lib/compute-stack.ts
+++ b/observability/eks-investigation-devops-agent/cdk/lib/compute-stack.ts
@@ -12,6 +12,7 @@ export interface ComputeStackProps extends cdk.StackProps {
   nodeInstanceType: string;
   nodeArchitecture: string; // 'arm64' | 'amd64'
   nodeDesiredCapacity: number;
+  kubernetesVersion: string;
 }
 
 export class ComputeStack extends cdk.Stack {
@@ -35,6 +36,7 @@ export class ComputeStack extends cdk.Stack {
       nodeInstanceType,
       nodeArchitecture,
       nodeDesiredCapacity,
+      kubernetesVersion,
     } = props;
 
     const isArm = nodeArchitecture === 'arm64';
@@ -67,12 +69,21 @@ export class ComputeStack extends cdk.Stack {
 
     // -----------------------------------------------------------------------
     // EKS Cluster — L1 CfnCluster to avoid L2 side effects
-    // (K8s 1.33, public+private endpoint, specified security group)
+    // (public+private endpoint, specified security group)
+    //
+    // supportType STANDARD auto-upgrades the cluster at end of standard
+    // support instead of entering (billable) extended support. It only takes
+    // effect at create time — extended support cannot be disabled once a
+    // cluster has entered it.
+    // https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
     // -----------------------------------------------------------------------
     const cluster = new eks.CfnCluster(this, 'EksCluster', {
       name: `${projectName}-${environment}-cluster`,
-      version: '1.33',
+      version: kubernetesVersion,
       roleArn: eksClusterRole.roleArn,
+      upgradePolicy: {
+        supportType: 'STANDARD',
+      },
       accessConfig: {
         authenticationMode: 'API_AND_CONFIG_MAP',
       },

--- a/observability/eks-investigation-devops-agent/cdk/lib/failure-simulator-api-stack.ts
+++ b/observability/eks-investigation-devops-agent/cdk/lib/failure-simulator-api-stack.ts
@@ -4,7 +4,7 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import { KubectlV31Layer } from '@aws-cdk/lambda-layer-kubectl-v31';
+import { KubectlV36Layer } from '@aws-cdk/lambda-layer-kubectl-v36';
 import { Construct } from 'constructs';
 import * as path from 'path';
 
@@ -108,9 +108,10 @@ export class FailureSimulatorApiStack extends cdk.Stack {
     });
 
     // -----------------------------------------------------------------------
-    // kubectl Lambda Layer
+    // kubectl Lambda Layer — keep within one minor version of the cluster
+    // (see eksKubernetesVersion in bin/app.ts).
     // -----------------------------------------------------------------------
-    const kubectlLayer = new KubectlV31Layer(this, 'KubectlLayer');
+    const kubectlLayer = new KubectlV36Layer(this, 'KubectlLayer');
 
     // -----------------------------------------------------------------------
     // Lambda Function

--- a/observability/eks-investigation-devops-agent/cdk/package.json
+++ b/observability/eks-investigation-devops-agent/cdk/package.json
@@ -8,7 +8,7 @@
     "cdk": "cdk"
   },
   "dependencies": {
-    "@aws-cdk/lambda-layer-kubectl-v31": "^2.0.0",
+    "@aws-cdk/lambda-layer-kubectl-v36": "^2.0.0",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.4.2"
   },

--- a/observability/eks-investigation-devops-agent/cdk/test/compute-architecture.property.test.ts
+++ b/observability/eks-investigation-devops-agent/cdk/test/compute-architecture.property.test.ts
@@ -47,6 +47,7 @@ function synthesizeComputeStack(architecture: string): Template {
     nodeInstanceType: architecture === 'arm64' ? 't4g.medium' : 't3.medium',
     nodeArchitecture: architecture,
     nodeDesiredCapacity: 2,
+    kubernetesVersion: '1.36',
   });
 
   return Template.fromStack(stack);

--- a/observability/eks-investigation-devops-agent/cdk/test/compute-iam-parity.property.test.ts
+++ b/observability/eks-investigation-devops-agent/cdk/test/compute-iam-parity.property.test.ts
@@ -106,6 +106,7 @@ function synthesizeComputeStack(environment: string, projectName: string): Templ
     nodeInstanceType: 't4g.medium',
     nodeArchitecture: 'arm64',
     nodeDesiredCapacity: 2,
+    kubernetesVersion: '1.36',
   });
 
   return Template.fromStack(stack);

--- a/observability/eks-investigation-devops-agent/cdk/test/output-key-parity.property.test.ts
+++ b/observability/eks-investigation-devops-agent/cdk/test/output-key-parity.property.test.ts
@@ -64,6 +64,7 @@ function synthesizeAll(env: string, arch: string) {
     eksSecurityGroup: net.eksSecurityGroup,
     nodeInstanceType: arch === 'arm64' ? 't4g.medium' : 't3.medium',
     nodeArchitecture: arch, nodeDesiredCapacity: 2,
+    kubernetesVersion: '1.36',
   });
   const pipeline = new PipelineStack(app, `DevOpsAgentEksPipeline-${region}`, {
     env: cdkEnv, environment: env, projectName, eksNodeArchitecture: arch,

--- a/observability/eks-investigation-devops-agent/cdk/test/resource-type-parity.property.test.ts
+++ b/observability/eks-investigation-devops-agent/cdk/test/resource-type-parity.property.test.ts
@@ -115,6 +115,7 @@ function synthesizeAll(env: string, arch: string) {
     eksSecurityGroup: net.eksSecurityGroup,
     nodeInstanceType: arch === 'arm64' ? 't4g.medium' : 't3.medium',
     nodeArchitecture: arch, nodeDesiredCapacity: 2,
+    kubernetesVersion: '1.36',
   });
   const pipeline = new PipelineStack(app, `DevOpsAgentEksPipeline-${region}`, {
     env: cdkEnv, environment: env, projectName, eksNodeArchitecture: arch,

--- a/observability/eks-investigation-devops-agent/deploy-all.ps1
+++ b/observability/eks-investigation-devops-agent/deploy-all.ps1
@@ -88,6 +88,16 @@ switch ($EksArchitecture) {
 }
 Write-Host "EKS architecture: $EksArchitecture"
 Write-Host "EKS instance:     $EksInstanceType"
+
+# ---------------------------------------------------------------------------
+# Kubernetes version — override via EKS_KUBERNETES_VERSION env var.
+# Keep this on a release still in EKS standard support; older versions bill
+# an extended-support surcharge per cluster hour. Upgrading an existing
+# cluster moves one minor version at a time, so step through if needed.
+# https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+# ---------------------------------------------------------------------------
+$EksKubernetesVersion = if ($env:EKS_KUBERNETES_VERSION) { $env:EKS_KUBERNETES_VERSION } else { "1.36" }
+Write-Host "EKS K8s version:  $EksKubernetesVersion"
 Write-Host ""
 
 $ECR_REGISTRY = "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
@@ -180,6 +190,7 @@ $cdkArgs = @(
     "-c", "eksNodeArchitecture=$EksArchitecture",
     "-c", "eksNodeInstanceType=$EksInstanceType",
     "-c", "eksNodeDesiredCapacity=2",
+    "-c", "eksKubernetesVersion=$EksKubernetesVersion",
     "-c", "devOpsAgentWebhookUrl=$DevOpsWebhookUrl",
     "-c", "devOpsAgentWebhookSecret=$DevOpsWebhookSecret",
     "-c", "devOpsAgentRegion=$DevOpsAgentRegion",
@@ -970,6 +981,7 @@ if ($NLB_HOSTNAME) {
         "-c", "eksNodeArchitecture=$EksArchitecture",
         "-c", "eksNodeInstanceType=$EksInstanceType",
         "-c", "eksNodeDesiredCapacity=2",
+        "-c", "eksKubernetesVersion=$EksKubernetesVersion",
         "-c", "apiGatewayEndpoint=$NLB_HOSTNAME",
         "-c", "devOpsAgentWebhookUrl=$DevOpsWebhookUrl",
         "-c", "devOpsAgentWebhookSecret=$DevOpsWebhookSecret",

--- a/observability/eks-investigation-devops-agent/deploy-all.sh
+++ b/observability/eks-investigation-devops-agent/deploy-all.sh
@@ -96,6 +96,16 @@ case "$EKS_ARCHITECTURE" in
         ;;
 esac
 echo "EKS architecture: $EKS_ARCHITECTURE"
+
+# ---------------------------------------------------------------------------
+# Kubernetes version — override via EKS_KUBERNETES_VERSION env var.
+# Keep this on a release still in EKS standard support; older versions bill
+# an extended-support surcharge per cluster hour. Upgrading an existing
+# cluster moves one minor version at a time, so step through if needed.
+# https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+# ---------------------------------------------------------------------------
+EKS_KUBERNETES_VERSION="${EKS_KUBERNETES_VERSION:-1.36}"
+echo "EKS Kubernetes version: $EKS_KUBERNETES_VERSION"
 echo "EKS instance:     $EKS_INSTANCE_TYPE"
 echo ""
 
@@ -185,7 +195,7 @@ echo ""
 # script) to avoid CloudFormation AlreadyExists conflicts.
 echo "[2/9] Deploying CDK stacks (this takes ~15 minutes)..."
 
-CDK_CONTEXT="-c environment=$ENVIRONMENT -c projectName=$PROJECT_NAME -c eksNodeArchitecture=$EKS_ARCHITECTURE -c eksNodeInstanceType=$EKS_INSTANCE_TYPE -c eksNodeDesiredCapacity=2 -c devOpsAgentWebhookUrl=$DEVOPS_WEBHOOK_URL -c devOpsAgentWebhookSecret=$DEVOPS_WEBHOOK_SECRET -c devOpsAgentRegion=$DEVOPS_AGENT_REGION -c devOpsAgentSpaceId=$DEVOPS_AGENT_SPACE_ID"
+CDK_CONTEXT="-c environment=$ENVIRONMENT -c projectName=$PROJECT_NAME -c eksNodeArchitecture=$EKS_ARCHITECTURE -c eksNodeInstanceType=$EKS_INSTANCE_TYPE -c eksNodeDesiredCapacity=2 -c eksKubernetesVersion=$EKS_KUBERNETES_VERSION -c devOpsAgentWebhookUrl=$DEVOPS_WEBHOOK_URL -c devOpsAgentWebhookSecret=$DEVOPS_WEBHOOK_SECRET -c devOpsAgentRegion=$DEVOPS_AGENT_REGION -c devOpsAgentSpaceId=$DEVOPS_AGENT_SPACE_ID"
 
 cd cdk
 npx cdk deploy --all \

--- a/observability/eks-investigation-devops-agent/docs/ARCHITECTURE.md
+++ b/observability/eks-investigation-devops-agent/docs/ARCHITECTURE.md
@@ -208,7 +208,7 @@ Container → Fluent Bit → CloudWatch Logs
 | Business Logic | Java + Spring Boot | 21.x / 3.5.x |
 | Webhooks | Node.js + TypeScript | 20.x |
 | Database | PostgreSQL | 15.x |
-| Container Orchestration | Amazon EKS | 1.33 |
+| Container Orchestration | Amazon EKS | 1.36 (default; see `EKS_KUBERNETES_VERSION`) |
 | IaC | AWS CDK (TypeScript) | 2.x |
 | Observability | CloudWatch + Fluent Bit | - |
 | Incident Response | AWS DevOps Agent | - |


### PR DESCRIPTION
Fixes Issue [#84](https://github.com/aws-samples/sample-aws-genai-ops-demos/issues/84)

  The EKS cluster version was hardcoded to 1.33 in `compute-stack.ts`. K8s 1.33 reached end of EKS standard support on 2026-07-29, so every cluster deployed from this demo now rolls into extended support automatically and bills $0.50/cluster/hour (~$12/day) on top of the normal per-cluster charge. Because `upgradePolicy` defaults to `EXTENDED` there is no failure and no approval step, just a larger bill — and because the version was hardcoded, operators could not  opt out without editing the stack.

  **1. Version is configurable.** Replaced with an `eksKubernetesVersion` CDK context parameter, defaulting to 1.36 (standard support until 2027-08-02), and surfaced in both deploy scripts as `EKS_KUBERNETES_VERSION` so the version can be chosen at deploy time. A new cluster can be created on any supported version, so  the newest default is correct for a fresh deploy; in-place upgrades still move one minor version at a time and should override to step through.

  **2. `upgradePolicy.supportType: STANDARD`.** This is what fixes the root cause.  Pinning a newer version alone only defers the problem — 1.36 would bill extended support the same way once it leaves standard support on 2027-08-02. `STANDARD`  makes EKS auto-upgrade the cluster instead. It applies at create time only,  because extended support cannot be disabled once a cluster has entered it, so this  protects future deployments rather than clusters already on 1.33.

  **3. kubectl layer v31 → v36.** The failure-simulator Lambda pinned   `@aws-cdk/lambda-layer-kubectl-v31`. kubectl is supported only within one minor   version of the control plane, so v31 against a 1.36 cluster would be a five-version skew.

  **Verified:** `tsc` clean, `bash -n` clean, 30/30 tests pass across 11 suites   (4 updated for the new required prop). `cdk synth` emits `Version: 1.36` and  `UpgradePolicy: {"SupportType": "STANDARD"}` on `AWS::EKS::Cluster`, with the node group untouched so it inherits the cluster version. The version change was also applied to two live 1.33 clusters (eu-central-1, eu-west-1) — CloudFormation reported "no interruption", an in-place control plane upgrade rather than a  replacement.

  **One open question:** is 1.36 the default you want? It suits fresh deploys, but for anyone running an existing 1.33 cluster from this demo it is a three-minor jump they would have to step through. Defaulting to 1.34 would upgrade those in a single step at the cost of a shorter runway (1.34 → 2026-12-02, 1.35 →  2027-03-27, 1.36 → 2027-08-02). Happy to switch if you prefer.

 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.