### PR TITLE
feat(shared): add get_bedrock_model_id utility for cross-region inference

### DIFF
--- a/.kiro/steering/contributor-guide.md
+++ b/.kiro/steering/contributor-guide.md
@@ -32,6 +32,24 @@ All demos align with one of five pillars:
 | **AWS Transform** | Documentation generation, code analysis, migration assessments |
 | **MCP Servers** | Tool integration, Kiro Powers |
 
+### Bedrock Model IDs
+
+**NEVER hardcode region-prefixed model IDs** (e.g., `us.anthropic.claude-sonnet-4-6`). Use the shared utility to get the correct cross-region inference (CRIS) prefix for the deployment region:
+
+```python
+from shared.utils.aws_utils import get_bedrock_model_id
+
+MODEL_ID = get_bedrock_model_id()  # Auto-prefixes based on region
+```
+
+For Lambdas, compute the model ID in the CDK stack and pass it as an environment variable:
+
+```python
+environment={"MODEL_ID": get_bedrock_model_id()}
+```
+
+See `shared/README.md` for full documentation on the region-to-prefix mapping.
+
 ### Infrastructure as Code
 
 **AWS CDK is required** — TypeScript (preferred) or Python. No Terraform or CloudFormation-only.

--- a/shared/README.md
+++ b/shared/README.md
@@ -90,6 +90,49 @@ if ([string]::IsNullOrEmpty($currentRegion)) {
 }
 ```
 
+## Bedrock Model ID (Cross-Region Inference)
+
+Newer Bedrock models (Claude Sonnet 4, 4.5, 4.6) are often only available via cross-region inference (CRIS) profiles. Use the shared utility to get the correct CRIS-prefixed model ID for the deployment region:
+
+### Python Usage
+```python
+from shared.utils.aws_utils import get_bedrock_model_id
+
+# Default model (anthropic.claude-sonnet-4-6)
+model_id = get_bedrock_model_id()
+# Returns: "eu.anthropic.claude-sonnet-4-6" in eu-west-1
+
+# Custom model
+model_id = get_bedrock_model_id("anthropic.claude-sonnet-4-5-20250929-v1:0")
+# Returns: "eu.anthropic.claude-sonnet-4-5-20250929-v1:0" in eu-west-1
+```
+
+### Region-to-prefix mapping
+
+| Region prefix | CRIS prefix | Data residency |
+|---|---|---|
+| `us-*` | `us.` | US only |
+| `eu-*` | `eu.` | EU only |
+| `ap-*` | `ap.` | APAC only |
+| Others (`ca-`, `me-`, `af-`, `sa-`, `il-`, `mx-`) | `global.` | Worldwide |
+
+### CDK pattern for Lambdas
+
+The recommended pattern is to compute the model ID in the CDK app (which has access to shared utils via PYTHONPATH) and pass it as a Lambda environment variable:
+
+```python
+# infrastructure/cdk/app.py or stack.py
+from shared.utils.aws_utils import get_bedrock_model_id
+
+lambda_.Function(
+    self, "MyFunction",
+    environment={"MODEL_ID": get_bedrock_model_id()},
+    ...
+)
+```
+
+The Lambda then reads `os.environ['MODEL_ID']` at runtime — no shared utils dependency needed in the Lambda bundle.
+
 ## Scripts
 
 ### Prerequisites Check

--- a/shared/utils/aws_utils.py
+++ b/shared/utils/aws_utils.py
@@ -66,3 +66,37 @@ def get_account_id() -> Optional[str]:
         pass
     
     return None
+
+
+def get_bedrock_model_id(model_name: str = "anthropic.claude-sonnet-4-6") -> str:
+    """
+    Get the correct cross-region inference (CRIS) prefixed model ID for the current region.
+
+    Amazon Bedrock newer models are often only available via cross-region inference
+    profiles. This function detects the deployment region and applies the appropriate
+    geographic prefix (us/eu/ap) or falls back to global for regions without a
+    dedicated geographic CRIS (ca, me, af, sa, il, mx).
+
+    Args:
+        model_name: Base model identifier without prefix (e.g. "anthropic.claude-sonnet-4-6")
+
+    Returns:
+        str: CRIS-prefixed model ID (e.g. "eu.anthropic.claude-sonnet-4-6")
+
+    Examples:
+        >>> os.environ['AWS_REGION'] = 'eu-west-1'
+        >>> get_bedrock_model_id()
+        'eu.anthropic.claude-sonnet-4-6'
+
+        >>> os.environ['AWS_REGION'] = 'us-east-1'
+        >>> get_bedrock_model_id("anthropic.claude-sonnet-4-5-20250929-v1:0")
+        'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+
+        >>> os.environ['AWS_REGION'] = 'ca-central-1'
+        >>> get_bedrock_model_id()
+        'global.anthropic.claude-sonnet-4-6'
+    """
+    region = get_region()
+    geo_prefix = region.split('-')[0]
+    cris_prefix = {'us': 'us', 'eu': 'eu', 'ap': 'ap'}.get(geo_prefix, 'global')
+    return f"{cris_prefix}.{model_name}"


### PR DESCRIPTION
Newer Bedrock models (Claude Sonnet 4, 4.5, 4.6) are often only available via cross-region inference (CRIS) profiles. Demos that hardcode a `us.` prefix break in EU/APAC regions, and demos without a prefix fail in regions where the model isn't available in-region.

## New utility

```python
from shared.utils.aws_utils import get_bedrock_model_id

model = get_bedrock_model_id()  # 'eu.anthropic.claude-sonnet-4-6' in eu-west-1
model = get_bedrock_model_id('anthropic.claude-sonnet-4-5-20250929-v1:0')  # custom model
```

## Region mapping

| Deployed in | CRIS prefix | Example |
|---|---|---|
| us-east-1, us-west-2 | `us.` | `us.anthropic.claude-sonnet-4-6` |
| eu-west-1, eu-central-1 | `eu.` | `eu.anthropic.claude-sonnet-4-6` |
| ap-southeast-1, ap-northeast-1 | `ap.` | `ap.anthropic.claude-sonnet-4-6` |
| ca-central-1, me-south-1, sa-east-1, etc. | `global.` | `global.anthropic.claude-sonnet-4-6` |

## Usage pattern for demos

CDK app computes the model ID at synth time and passes it as a Lambda environment variable:

```python
# infrastructure/cdk/app.py
from shared.utils.aws_utils import get_bedrock_model_id

environment={'MODEL_ID': get_bedrock_model_id()}
```

Lambda reads the env var at runtime — no shared utils dependency needed in the Lambda bundle.

## Context

Discovered while testing PR #88 — the demo hardcoded `us.anthropic.claude-sonnet-4-6` which fails in eu-west-1. This utility provides the standard solution for all demos.