### PR TITLE
fix(shared): reinstall CDK deps when node_modules is incomplete

### DIFF
--- a/shared/scripts/deploy-cdk.ps1
+++ b/shared/scripts/deploy-cdk.ps1
@@ -44,8 +44,23 @@ try {
         pip install -r requirements.txt -q 2>$null
         Write-Host "      OK: Python CDK dependencies installed" -ForegroundColor Green
     } elseif (Test-Path "package.json") {
-        if (-not (Test-Path "node_modules")) {
-            npm install 2>$null
+        # Install when node_modules is missing OR incomplete. A previous interrupted
+        # install can leave a partial node_modules that lacks declared dependencies,
+        # which then causes confusing CDK synth/compile errors. Verify completeness
+        # with `npm ls` (non-zero exit => missing/unmet deps) instead of only checking
+        # for the directory's existence.
+        $nodeModulesComplete = $false
+        if (Test-Path "node_modules") {
+            npm ls --prod --silent 2>$null | Out-Null
+            $nodeModulesComplete = ($LASTEXITCODE -eq 0)
+        }
+        if (-not $nodeModulesComplete) {
+            if (Test-Path "package-lock.json") {
+                # Deterministic, clean install from the lockfile.
+                npm ci 2>$null
+            } else {
+                npm install 2>$null
+            }
         }
         Write-Host "      OK: Node.js CDK dependencies installed" -ForegroundColor Green
     } else {

--- a/shared/scripts/deploy-cdk.sh
+++ b/shared/scripts/deploy-cdk.sh
@@ -88,9 +88,19 @@ if [ -f "requirements.txt" ]; then
     CDK_APP_OVERRIDE="--app 'python3 app.py'"
     echo -e "\033[0;32m      OK: Python CDK dependencies installed\033[0m"
 elif [ -f "package.json" ]; then
-    # TypeScript/JavaScript CDK project
-    if [ ! -d "node_modules" ]; then
-        npm install
+    # TypeScript/JavaScript CDK project.
+    # Install when node_modules is missing OR incomplete. A previous interrupted
+    # install can leave a partial node_modules that lacks declared dependencies,
+    # which then causes confusing CDK synth/compile errors. Verify completeness
+    # with `npm ls` (non-zero exit => missing/unmet deps) instead of only checking
+    # for the directory's existence.
+    if [ ! -d "node_modules" ] || ! npm ls --prod --silent > /dev/null 2>&1; then
+        if [ -f "package-lock.json" ]; then
+            # Deterministic, clean install from the lockfile.
+            npm ci
+        else
+            npm install
+        fi
     fi
     echo -e "\033[0;32m      ✓ Node.js CDK dependencies installed\033[0m"
 else


### PR DESCRIPTION
## Problem

The shared `deploy-cdk.sh` / `deploy-cdk.ps1` scripts only run `npm install` when `node_modules` is **absent**:

```bash
if [ ! -d "node_modules" ]; then
    npm install
fi
```

If a previous install was interrupted, `node_modules` exists but is **incomplete** (missing declared deps). The scripts then skip the repair, and CDK synth fails later with confusing TypeScript errors that don't point at the real cause:

```
error TS2307: Cannot find module 'aws-cdk-lib'
error TS2591: Cannot find name 'process'  (missing @types/node)
error TS2882: ... side-effect import of 'source-map-support/register'
```

This was hit for real while deploying `aws-services-lifecycle-tracker` — `node_modules` had `aws-cdk-lib` but was missing `@types/node` and `source-map-support`, and the deploy failed at bootstrap/synth.

## Fix

Detect an incomplete install, not just a missing directory:
- Verify completeness with `npm ls` (non-zero exit => missing/unmet deps) in addition to the directory check.
- Prefer `npm ci` when a `package-lock.json` is present (deterministic, clean install); fall back to `npm install` otherwise.
- Applied to **both** `deploy-cdk.sh` and `deploy-cdk.ps1` for platform parity.

This is a shared script used by every demo, so the fix benefits the whole library.

## Testing

- `bash -n deploy-cdk.sh` — parses cleanly.
- Verified `npm ls --prod --silent` returns exit 0 on a complete `node_modules` (would correctly skip reinstall) and non-zero on an incomplete one (would trigger reinstall).
- **PowerShell twin not parse-checked locally** (no `pwsh` on the dev machine) — it's a direct mirror of the bash logic; a Windows reviewer confirming `deploy-cdk.ps1` would be appreciated.

## Notes

- No behavior change when `node_modules` is already complete (still skips install).
- Region detection and all other logic untouched.