### PR TITLE
docs+i18n(lifecycle-tracker): Support plan prerequisite + English translation

### DIFF
--- a/operations-automation/aws-services-lifecycle-tracker/README.md
+++ b/operations-automation/aws-services-lifecycle-tracker/README.md
@@ -107,6 +107,7 @@ Simplified Flow:
   - AWS SSO: `aws sso login --profile <profile-name>`
   - Environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
 - **No Docker required!** (CodeBuild handles container builds)
+- **Paid AWS Support plan** (**AWS Business Support+, Enterprise Support, or Unified Operations**) — required for the AWS Health API integration. Accounts on Basic/Developer support receive a `SubscriptionRequiredException` when the tracker calls the Health API, and the AWS Health panel will not populate. See [What is AWS Health](https://docs.aws.amazon.com/health/latest/ug/what-is-aws-health.html). The rest of the demo (documentation extraction, deprecation tracking) works without a paid plan.
 
 ### ⚠️ Important: Region Requirements
 

--- a/operations-automation/aws-services-lifecycle-tracker/agent/health_enricher.py
+++ b/operations-automation/aws-services-lifecycle-tracker/agent/health_enricher.py
@@ -16,25 +16,25 @@ logger = logging.getLogger(__name__)
 
 
 class HealthEnricher:
-    """Enrichissement des événements Health avec données lifecycle."""
+    """Enriches Health events with lifecycle data."""
 
     def enrich_events(self, events: List[dict], service_configs: dict) -> List[dict]:
         """
-        Enrichit les événements avec les données de cycle de vie.
+        Enrich events with lifecycle data.
 
-        Pour chaque événement:
-        1. Mappe le service Health vers le service_name lifecycle (via health_event_mapping)
-        2. Récupère les items lifecycle du service concerné
-        3. Ajoute les versions en dépréciation/fin de support
-        4. Calcule la priorité (élevée si scheduledChange + items deprecated)
+        For each event:
+        1. Map the Health service to the lifecycle service_name (via health_event_mapping)
+        2. Retrieve the lifecycle items for the matched service
+        3. Add the deprecated / end-of-support versions
+        4. Calculate the priority (higher for scheduledChange + deprecated items)
 
         Args:
-            events: Liste d'événements Health bruts (depuis HealthCollector).
-            service_configs: Dictionnaire des configurations de services
-                            (contenu de service_configs.json['services']).
+            events: List of raw Health events (from HealthCollector).
+            service_configs: Dictionary of service configurations
+                            (contents of service_configs.json['services']).
 
         Returns:
-            Liste d'événements enrichis prêts pour le stockage.
+            List of enriched events ready for storage.
         """
         enriched_events: List[dict] = []
 
@@ -79,20 +79,19 @@ class HealthEnricher:
 
     def _map_service_name(self, health_service: str, service_configs: dict) -> Optional[str]:
         """
-        Mappe le nom de service Health API vers le service_name interne.
+        Map the Health API service name to the internal service_name.
 
-        Recherche dans les service_configs un service dont le champ
-        'health_event_mapping' correspond au nom du service Health.
-        Si aucun mapping explicite n'est trouvé, tente un matching
-        insensible à la casse sur le nom du service.
+        Looks in service_configs for a service whose 'health_event_mapping'
+        field matches the Health service name. If no explicit mapping is
+        found, falls back to a case-insensitive match on the service name.
 
         Args:
-            health_service: Nom du service tel que retourné par l'API Health
-                           (ex: 'LAMBDA', 'EKS', 'RDS').
-            service_configs: Dictionnaire des configurations de services.
+            health_service: Service name as returned by the Health API
+                           (e.g. 'LAMBDA', 'EKS', 'RDS').
+            service_configs: Dictionary of service configurations.
 
         Returns:
-            Le service_name interne correspondant, ou None si non trouvé.
+            The matching internal service_name, or None if not found.
         """
         if not health_service:
             return None
@@ -113,7 +112,7 @@ class HealthEnricher:
 
     def _calculate_priority(self, event: dict, lifecycle_items: List[dict]) -> str:
         """
-        Calcule la priorité : critical, high, medium, low.
+        Calculate the priority: critical, high, medium, low.
 
         Rules:
         - issue with status_code=open → critical
@@ -122,11 +121,11 @@ class HealthEnricher:
         - accountNotification → low
 
         Args:
-            event: Événement Health avec les champs event_type_category et status_code.
-            lifecycle_items: Liste des items lifecycle du service concerné.
+            event: Health event with event_type_category and status_code fields.
+            lifecycle_items: List of lifecycle items for the matched service.
 
         Returns:
-            Priorité calculée: 'critical', 'high', 'medium', ou 'low'.
+            Calculated priority: 'critical', 'high', 'medium', or 'low'.
         """
         event_type_category = event.get('event_type_category', '')
         status_code = event.get('status_code', '')
@@ -165,17 +164,17 @@ class HealthEnricher:
 
     def _format_health_notification(self, event: dict, enrichment: dict) -> dict:
         """
-        Formate la notification finale pour stockage.
+        Format the final notification for storage.
 
         Includes: time_remaining for future scheduledChange events.
 
         Args:
-            event: Événement Health formaté par HealthCollector.
-            enrichment: Données d'enrichissement incluant service_name,
-                       lifecycle_items, deprecated_items, et priority.
+            event: Health event formatted by HealthCollector.
+            enrichment: Enrichment data including service_name,
+                       lifecycle_items, deprecated_items, and priority.
 
         Returns:
-            Notification formatée prête pour stockage DynamoDB.
+            Formatted notification ready for DynamoDB storage.
         """
         notification = {
             # Core event fields
@@ -212,17 +211,17 @@ class HealthEnricher:
 
     def _get_lifecycle_items(self, service_name: str, service_configs: dict) -> List[dict]:
         """
-        Récupère les items lifecycle depuis DynamoDB pour un service donné.
+        Retrieve lifecycle items from DynamoDB for a given service.
 
-        Tente de lire depuis la table lifecycle via database_reads.
-        En cas d'erreur, retourne une liste vide.
+        Attempts to read from the lifecycle table via database_reads.
+        Returns an empty list on error.
 
         Args:
-            service_name: Nom interne du service.
-            service_configs: Configurations des services (pour contexte).
+            service_name: Internal service name.
+            service_configs: Service configurations (for context).
 
         Returns:
-            Liste des items lifecycle du service.
+            List of lifecycle items for the service.
         """
         try:
             from database_reads import list_deprecations
@@ -248,13 +247,13 @@ class HealthEnricher:
 
     def _build_lifecycle_context(self, enrichment: dict) -> dict:
         """
-        Construit le contexte lifecycle pour inclusion dans la notification.
+        Build the lifecycle context for inclusion in the notification.
 
         Args:
-            enrichment: Données d'enrichissement.
+            enrichment: Enrichment data.
 
         Returns:
-            Dictionnaire du contexte lifecycle (versions deprecated, dates).
+            Lifecycle context dictionary (deprecated versions, dates).
         """
         deprecated_items = enrichment.get('deprecated_items', [])
 
@@ -284,13 +283,13 @@ class HealthEnricher:
 
     def _determine_notification_status(self, event: dict) -> str:
         """
-        Détermine le statut de notification basé sur l'événement.
+        Determine the notification status based on the event.
 
         Args:
-            event: Événement Health.
+            event: Health event.
 
         Returns:
-            'active' ou 'resolved'.
+            'active' or 'resolved'.
         """
         status_code = event.get('status_code', '')
         if status_code == 'closed':
@@ -300,15 +299,15 @@ class HealthEnricher:
     @staticmethod
     def _calculate_time_remaining(start_time_str: str) -> Optional[str]:
         """
-        Calcule le temps restant avant un événement scheduledChange futur.
+        Calculate the time remaining before a future scheduledChange event.
 
         Args:
-            start_time_str: Date de début en format ISO 8601.
+            start_time_str: Start date in ISO 8601 format.
 
         Returns:
-            Chaîne humaine représentant le temps restant
-            (ex: '5 days, 3 hours'), ou None si l'événement est dans
-            le passé ou la date invalide.
+            Human-readable string representing the time remaining
+            (e.g. '5 days, 3 hours'), or None if the event is in the
+            past or the date is invalid.
         """
         if not start_time_str:
             return None

--- a/operations-automation/aws-services-lifecycle-tracker/frontend/src/components/HealthPanel.tsx
+++ b/operations-automation/aws-services-lifecycle-tracker/frontend/src/components/HealthPanel.tsx
@@ -39,15 +39,15 @@ function getSeverityIndicatorType(severity: string): 'error' | 'warning' | 'info
 function getSeverityLabel(severity: string): string {
   switch (severity) {
     case 'critical':
-      return 'Critique';
+      return 'Critical';
     case 'high':
     case 'warning':
-      return 'Avertissement';
+      return 'Warning';
     case 'medium':
     case 'info':
-      return 'Informatif';
+      return 'Informational';
     case 'low':
-      return 'Faible';
+      return 'Low';
     default:
       return severity;
   }
@@ -61,7 +61,7 @@ function getCategoryLabel(category: string): string {
     case 'issue':
       return 'Incident';
     case 'scheduledChange':
-      return 'Maintenance planifiée';
+      return 'Scheduled maintenance';
     case 'accountNotification':
       return 'Notification';
     default:
@@ -104,7 +104,7 @@ export default function HealthPanel() {
       const data = await fetchHealthSummary();
       setHealthData(data);
     } catch (err: any) {
-      setError(err.message || 'Erreur lors du chargement des données Health');
+      setError(err.message || 'Error loading Health data');
     } finally {
       setLoading(false);
     }
@@ -116,7 +116,7 @@ export default function HealthPanel() {
         header={<Header variant="h2">AWS Health</Header>}
       >
         <Box textAlign="center" padding="l">
-          <StatusIndicator type="loading">Chargement des événements Health...</StatusIndicator>
+          <StatusIndicator type="loading">Loading Health events...</StatusIndicator>
         </Box>
       </Container>
     );
@@ -130,7 +130,7 @@ export default function HealthPanel() {
             variant="h2"
             actions={
               <Button iconName="refresh" onClick={loadHealthData}>
-                Actualiser
+                Refresh
               </Button>
             }
           >
@@ -165,10 +165,10 @@ export default function HealthPanel() {
         <Box textAlign="center" padding="l">
           <SpaceBetween size="xs" alignItems="center">
             <StatusIndicator type="success">
-              Statut opérationnel normal
+              Normal operational status
             </StatusIndicator>
             <Box variant="small" color="text-body-secondary">
-              Aucun événement actif détecté sur vos services
+              No active events detected on your services
             </Box>
           </SpaceBetween>
         </Box>
@@ -196,7 +196,7 @@ export default function HealthPanel() {
                     <SpaceBetween size="xxs">
                       <Box>
                         <StatusIndicator type={getSeverityIndicatorType(event.severity)}>
-                          {event.event_type_code || event.description?.substring(0, 80) || 'Événement Health'}
+                          {event.event_type_code || event.description?.substring(0, 80) || 'Health event'}
                         </StatusIndicator>
                       </Box>
                       <Box variant="small" color="text-body-secondary">

--- a/operations-automation/aws-services-lifecycle-tracker/frontend/src/pages/ServiceDetail.tsx
+++ b/operations-automation/aws-services-lifecycle-tracker/frontend/src/pages/ServiceDetail.tsx
@@ -23,13 +23,13 @@ import {
 function getSeverityIndicator(severity: string) {
   switch (severity) {
     case 'critical':
-      return <StatusIndicator type="error">Critique</StatusIndicator>;
+      return <StatusIndicator type="error">Critical</StatusIndicator>;
     case 'high':
-      return <StatusIndicator type="warning">Élevée</StatusIndicator>;
+      return <StatusIndicator type="warning">High</StatusIndicator>;
     case 'medium':
-      return <StatusIndicator type="info">Moyenne</StatusIndicator>;
+      return <StatusIndicator type="info">Medium</StatusIndicator>;
     case 'low':
-      return <StatusIndicator type="success">Faible</StatusIndicator>;
+      return <StatusIndicator type="success">Low</StatusIndicator>;
     default:
       return <StatusIndicator>{severity}</StatusIndicator>;
   }
@@ -40,7 +40,7 @@ function getCategoryBadge(category: string) {
     case 'issue':
       return <Badge color="red">Incident</Badge>;
     case 'scheduledChange':
-      return <Badge color="blue">Maintenance planifiée</Badge>;
+      return <Badge color="blue">Scheduled maintenance</Badge>;
     case 'accountNotification':
       return <Badge color="grey">Notification</Badge>;
     default:
@@ -51,11 +51,11 @@ function getCategoryBadge(category: string) {
 function getStatusBadge(statusCode: string) {
   switch (statusCode) {
     case 'open':
-      return <StatusIndicator type="error">Ouvert</StatusIndicator>;
+      return <StatusIndicator type="error">Open</StatusIndicator>;
     case 'upcoming':
-      return <StatusIndicator type="warning">À venir</StatusIndicator>;
+      return <StatusIndicator type="warning">Upcoming</StatusIndicator>;
     case 'closed':
-      return <StatusIndicator type="success">Résolu</StatusIndicator>;
+      return <StatusIndicator type="success">Resolved</StatusIndicator>;
     default:
       return <StatusIndicator>{statusCode}</StatusIndicator>;
   }
@@ -128,7 +128,7 @@ export default function ServiceDetail() {
       <Container>
         <Box textAlign="center" padding="xxl">
           <Spinner size="large" />
-          <Box padding={{ top: 's' }}>Chargement du service...</Box>
+          <Box padding={{ top: 's' }}>Loading service...</Box>
         </Box>
       </Container>
     );
@@ -138,12 +138,12 @@ export default function ServiceDetail() {
     return (
       <Container>
         <Box textAlign="center" padding="xxl">
-          <Box variant="h2">Service non trouvé</Box>
+          <Box variant="h2">Service not found</Box>
           <Box padding={{ top: 's' }}>
-            Le service « {serviceName} » n'existe pas dans la configuration.
+            The service "{serviceName}" does not exist in the configuration.
           </Box>
           <Box padding={{ top: 'm' }}>
-            <Button onClick={() => navigate('/services')}>Retour aux services</Button>
+            <Button onClick={() => navigate('/services')}>Back to services</Button>
           </Box>
         </Box>
       </Container>
@@ -163,10 +163,10 @@ export default function ServiceDetail() {
             variant="h1"
             actions={
               <Button variant="normal" iconName="arrow-left" onClick={() => navigate('/services')}>
-                Retour aux services
+                Back to services
               </Button>
             }
-            description={`Détails et événements Health pour ${service.name}`}
+            description={`Details and Health events for ${service.name}`}
           >
             {service.name}
           </Header>
@@ -174,29 +174,29 @@ export default function ServiceDetail() {
       >
         <ColumnLayout columns={4} variant="text-grid">
           <div>
-            <Box variant="awsui-key-label">Identifiant</Box>
+            <Box variant="awsui-key-label">Identifier</Box>
             <Box>{service.service_name}</Box>
           </div>
           <div>
-            <Box variant="awsui-key-label">Statut</Box>
+            <Box variant="awsui-key-label">Status</Box>
             <Box>
               {service.enabled ? (
-                <StatusIndicator type="success">Activé</StatusIndicator>
+                <StatusIndicator type="success">Enabled</StatusIndicator>
               ) : (
-                <StatusIndicator type="stopped">Désactivé</StatusIndicator>
+                <StatusIndicator type="stopped">Disabled</StatusIndicator>
               )}
             </Box>
           </div>
           <div>
-            <Box variant="awsui-key-label">Dernière extraction</Box>
+            <Box variant="awsui-key-label">Last extraction</Box>
             <Box>
               {service.last_extraction
                 ? new Date(service.last_extraction).toLocaleString()
-                : 'Jamais'}
+                : 'Never'}
             </Box>
           </div>
           <div>
-            <Box variant="awsui-key-label">Nombre d'extractions</Box>
+            <Box variant="awsui-key-label">Extraction count</Box>
             <Box>{service.extraction_count || 0}</Box>
           </div>
         </ColumnLayout>
@@ -206,17 +206,17 @@ export default function ServiceDetail() {
       <ExpandableSection
         variant="container"
         defaultExpanded={true}
-        headerText={`Événements AWS Health (${activeHealthEvents.length} actif${activeHealthEvents.length !== 1 ? 's' : ''})`}
-        headerDescription="Incidents, maintenances planifiées et notifications affectant ce service"
+        headerText={`AWS Health events (${activeHealthEvents.length} active)`}
+        headerDescription="Incidents, scheduled maintenance, and notifications affecting this service"
       >
         {loadingHealth ? (
           <Box textAlign="center" padding="l">
-            <Spinner /> Chargement des événements Health...
+            <Spinner /> Loading Health events...
           </Box>
         ) : activeHealthEvents.length === 0 ? (
           <Box textAlign="center" padding="l">
             <StatusIndicator type="success">
-              Aucun événement Health actif — statut opérationnel normal
+              No active Health events — normal operational status
             </StatusIndicator>
           </Box>
         ) : (
@@ -224,7 +224,7 @@ export default function ServiceDetail() {
             columnDefinitions={[
               {
                 id: 'severity',
-                header: 'Sévérité',
+                header: 'Severity',
                 cell: (item) => getSeverityIndicator(item.severity),
                 width: 120,
               },
@@ -236,7 +236,7 @@ export default function ServiceDetail() {
               },
               {
                 id: 'status',
-                header: 'Statut',
+                header: 'Status',
                 cell: (item) => getStatusBadge(item.status_code),
                 width: 110,
               },
@@ -256,13 +256,13 @@ export default function ServiceDetail() {
               },
               {
                 id: 'region',
-                header: 'Région',
+                header: 'Region',
                 cell: (item) => item.region || '-',
                 width: 130,
               },
               {
                 id: 'start_time',
-                header: 'Début',
+                header: 'Start',
                 cell: (item) =>
                   item.start_time
                     ? new Date(item.start_time).toLocaleString()
@@ -274,7 +274,7 @@ export default function ServiceDetail() {
             variant="embedded"
             empty={
               <Box textAlign="center" color="inherit" padding="s">
-                Aucun événement Health actif
+                No active Health events
               </Box>
             }
           />
@@ -285,23 +285,23 @@ export default function ServiceDetail() {
       <ExpandableSection
         variant="container"
         defaultExpanded={true}
-        headerText={`Données de cycle de vie (${deprecations.length} élément${deprecations.length !== 1 ? 's' : ''})`}
-        headerDescription="Éléments de dépréciation et fin de support pour ce service"
+        headerText={`Lifecycle data (${deprecations.length} item${deprecations.length !== 1 ? 's' : ''})`}
+        headerDescription="Deprecation and end-of-support items for this service"
       >
         {loadingDeprecations ? (
           <Box textAlign="center" padding="l">
-            <Spinner /> Chargement des données de cycle de vie...
+            <Spinner /> Loading lifecycle data...
           </Box>
         ) : deprecations.length === 0 ? (
           <Box textAlign="center" padding="l" color="text-body-secondary">
-            Aucune donnée de cycle de vie extraite pour ce service.
+            No lifecycle data extracted for this service.
           </Box>
         ) : (
           <Table
             columnDefinitions={[
               {
                 id: 'name',
-                header: 'Nom',
+                header: 'Name',
                 cell: (item) => (
                   <SpaceBetween size="xxxs">
                     <Box variant="strong">
@@ -317,7 +317,7 @@ export default function ServiceDetail() {
               },
               {
                 id: 'status',
-                header: 'Statut',
+                header: 'Status',
                 cell: (item) => {
                   switch (item.status) {
                     case 'deprecated':
@@ -334,7 +334,7 @@ export default function ServiceDetail() {
               },
               {
                 id: 'dates',
-                header: 'Dates clés',
+                header: 'Key dates',
                 cell: (item) => {
                   const dateFields = [
                     'deprecation_date',
@@ -359,7 +359,7 @@ export default function ServiceDetail() {
               },
               {
                 id: 'last_verified',
-                header: 'Dernière vérification',
+                header: 'Last verified',
                 cell: (item) => (
                   <Box variant="small">
                     {new Date(item.last_verified).toLocaleDateString()}
@@ -372,7 +372,7 @@ export default function ServiceDetail() {
             variant="embedded"
             empty={
               <Box textAlign="center" color="inherit" padding="s">
-                Aucune donnée de cycle de vie
+                No lifecycle data
               </Box>
             }
           />

--- a/operations-automation/aws-services-lifecycle-tracker/scripts/discover_services.py
+++ b/operations-automation/aws-services-lifecycle-tracker/scripts/discover_services.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Script de découverte des services AWS avec pages de dépréciation.
-Exécution manuelle : python scripts/discover_services.py
+Discovery script for AWS services with deprecation pages.
+Manual run: python scripts/discover_services.py
 
-Parcourt les patterns connus de documentation AWS pour identifier
-les services publiant des informations de cycle de vie.
+Walks known AWS documentation URL patterns to identify services
+that publish lifecycle information.
 """
 import json
 import argparse
@@ -263,7 +263,7 @@ CATEGORIZATION_PATTERNS: dict[str, list[str]] = {
 
 def discover_lifecycle_pages() -> list[dict]:
     """
-    Découvre les pages de documentation contenant des informations lifecycle.
+    Discover documentation pages containing lifecycle information.
 
     Scans known AWS documentation URL patterns to identify services
     that publish lifecycle/deprecation information.
@@ -288,7 +288,7 @@ def discover_lifecycle_pages() -> list[dict]:
 
 def categorize_service(service_name: str, url: str) -> str:
     """
-    Catégorise un service par type de cycle de vie en analysant l'URL.
+    Categorize a service by lifecycle type by analyzing the URL.
 
     Uses URL pattern matching to determine the lifecycle type category
     for a given service documentation URL. Longer (more specific) pattern
@@ -359,7 +359,7 @@ def _categorize_by_service_name(service_name: str) -> str:
 
 def generate_config_template(candidates: list[dict]) -> dict:
     """
-    Génère un template Service_Config pour les candidats découverts.
+    Generate a Service_Config template for the discovered candidates.
 
     Produces a JSON-compatible dict with Service_Config entries for each
     discovered candidate, ready to be merged into service_configs.json.


### PR DESCRIPTION
Addresses part of #99 (E6 and I3) — two low-risk, mechanical fixes.

## E6 — Document paid Support plan prerequisite
The AWS Health API integration requires a paid Support plan. Added to the README prerequisites:
- **AWS Business Support+, Enterprise Support, or Unified Operations** required for the Health API integration.
- Accounts on Basic/Developer support get `SubscriptionRequiredException`; the Health panel won't populate.
- Clarified the rest of the demo (doc extraction, deprecation tracking) works without a paid plan.
- Uses current plan tiers per the [Health User Guide](https://docs.aws.amazon.com/health/latest/ug/what-is-aws-health.html).

## I3 — Translate French to English
The repo is English-language (per the contributor guide), but the Health slice added in #67 contained French. Translated:
- `frontend/src/components/HealthPanel.tsx` — user-facing UI strings (severity/category labels, loading/empty/error states, refresh button)
- `frontend/src/pages/ServiceDetail.tsx` — UI strings and table headers
- `agent/health_enricher.py` — class/method docstrings
- `scripts/discover_services.py` — module/function docstrings

## Scope & testing
- String and docstring changes only — no logic changes.
- Python files compile (`py_compile`).
- Confirmed no French remains in the four files.
- The two edited `.tsx` files have no new TypeScript errors. (Note: a bare `tsc --noEmit` surfaces pre-existing errors in *other* frontend files — missing vite/client types, SDK type mismatches — unrelated to this change and not introduced here.)

Remaining items from #99 (E7/E8 UI bugs, I1/I2 data-source work, I4/I5 roadmap) are out of scope for this quick fix.