### PR TITLE
fix(shared): correct APAC CRIS prefix (ap -> apac) in get_bedrock_model_id

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -113,7 +113,7 @@ model_id = get_bedrock_model_id("anthropic.claude-sonnet-4-5-20250929-v1:0")
 |---|---|---|
 | `us-*` | `us.` | US only |
 | `eu-*` | `eu.` | EU only |
-| `ap-*` | `ap.` | APAC only |
+| `ap-*` | `apac.` | APAC only |
 | Others (`ca-`, `me-`, `af-`, `sa-`, `il-`, `mx-`) | `global.` | Worldwide |
 
 ### CDK pattern for Lambdas

--- a/shared/utils/aws_utils.py
+++ b/shared/utils/aws_utils.py
@@ -98,5 +98,8 @@ def get_bedrock_model_id(model_name: str = "anthropic.claude-sonnet-4-6") -> str
     """
     region = get_region()
     geo_prefix = region.split('-')[0]
-    cris_prefix = {'us': 'us', 'eu': 'eu', 'ap': 'ap'}.get(geo_prefix, 'global')
+    # Asia Pacific's CRIS profile prefix is "apac", not "ap". Mapping ap-* to
+    # "ap" produces an invalid inference profile ID (e.g. "ap.anthropic.*")
+    # that fails at invoke time in every ap-* region.
+    cris_prefix = {'us': 'us', 'eu': 'eu', 'ap': 'apac'}.get(geo_prefix, 'global')
     return f"{cris_prefix}.{model_name}"


### PR DESCRIPTION
## Problem
`shared/utils/aws_utils.py` → `get_bedrock_model_id()` maps `ap-*` regions to the CRIS prefix **`ap`**:

```python
cris_prefix = {'us': 'us', 'eu': 'eu', 'ap': 'ap'}.get(geo_prefix, 'global')
```

But the real Amazon Bedrock cross-region inference prefix for Asia Pacific is **`apac`**. So in any `ap-*` region this produces an invalid inference profile ID like `ap.anthropic.claude-opus-4-8`, which **fails at invoke time**. This silently breaks every demo that relies on the shared util when deployed in an `ap-*` region (e.g. `ap-northeast-2`, `ap-southeast-2`).

Credit: spotted while reviewing #97, whose container-local `aws_utils.py` already documents and works around this exact bug.

## Fix
- Map `ap` → `apac` (with an explanatory comment).
- Fix the region-to-prefix table in `shared/README.md` (also said `ap.`).

## Verification
Resolved IDs across geographies after the fix:

| Region | Result |
|---|---|
| `eu-west-1` | `eu.anthropic.claude-opus-4-8` |
| `us-east-1` | `us.anthropic.claude-opus-4-8` |
| `ap-northeast-2` | `apac.anthropic.claude-opus-4-8` ✅ (was `ap.`) |
| `ap-southeast-2` | `apac.anthropic.claude-opus-4-8` ✅ (was `ap.`) |
| `ca-central-1` | `global.anthropic.claude-opus-4-8` |

Only `ap-*` behavior changes; us/eu/global are unaffected.