### PR TITLE
improve(hooks): enforce governance via command hook; move conformity …

### DIFF
--- a/.kiro/hooks/pre-write-conformity.json
+++ b/.kiro/hooks/pre-write-conformity.json
@@ -2,13 +2,12 @@
   "version": "v1",
   "hooks": [
     {
-      "name": "Pre-Write Conformity Check",
-      "description": "Verify file changes follow project standards before writing",
-      "trigger": "PreToolUse",
-      "matcher": "^(fs_write|fs_append|str_replace|delete_file|code)$",
+      "name": "Conformity Review (post-change)",
+      "description": "Review the completed change set against project standards once, at the end of a turn, instead of on every individual write. Deterministic checks (regions, tracking IDs, stack naming) are enforced in CI; the contributor-guide is always-on steering, so per-write prompting was redundant and slow.",
+      "trigger": "Stop",
       "action": {
         "type": "agent",
-        "prompt": "Before making this change, check it against the standards in .kiro/steering/contributor-guide.md (naming, file location, shared utilities, CDK requirement, no hardcoded regions) and .kiro/steering/solution-adoption-tracking.md (tracking in app file). If the change would violate a standard, flag it and suggest the compliant approach."
+        "prompt": "Review any code changes made this turn against the standards in .kiro/steering/contributor-guide.md (naming, file location, shared utilities, CDK requirement, no hardcoded regions) and .kiro/steering/solution-adoption-tracking.md (tracking in the CDK app file, main stack only). If any change violates a standard, flag it and suggest the compliant fix. If everything conforms, say nothing."
       },
       "enabled": true
     }

--- a/.kiro/hooks/protect-governance.json
+++ b/.kiro/hooks/protect-governance.json
@@ -3,12 +3,12 @@
   "hooks": [
     {
       "name": "Protect Governance Files",
-      "description": "Prevent agent from modifying steering files and hooks",
+      "description": "Block agent writes to .kiro/steering/ and .kiro/hooks/ (hard enforcement via exit code 2, path-based)",
       "trigger": "PreToolUse",
-      "matcher": "^(fs_write|fs_append|str_replace|delete_file|code)$",
+      "matcher": "^(fs_write|fs_append|str_replace|delete_file|smart_relocate|code)$",
       "action": {
-        "type": "agent",
-        "prompt": "If this write targets any file under .kiro/steering/ or .kiro/hooks/, STOP. Do not modify these governance files. They are maintained by repo owners only. Explain this to the user and suggest they contact the maintainers if changes are needed."
+        "type": "command",
+        "command": "bash .kiro/hooks/scripts/protect-governance.sh"
       },
       "enabled": true
     }

--- a/.kiro/hooks/scripts/protect-governance.sh
+++ b/.kiro/hooks/scripts/protect-governance.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# PreToolUse guard: block agent writes to governance files under
+# .kiro/steering/ or .kiro/hooks/.
+#
+# Receives the tool invocation as JSON on stdin. Extracts every candidate
+# target path and exits:
+#   - exit 2  -> block the write (stderr is forwarded to the agent)
+#   - exit 0  -> allow (silent, near-instant path check)
+#
+# This replaces the previous agent-type hook, which could only *ask* the
+# agent to self-check and fired on every write regardless of path.
+
+input="$(cat)"
+
+# Extract ALL candidate paths from common write-tool fields. smart_relocate
+# has both sourcePath and destinationPath, so we must check every one, not
+# just the first. Uses python3 for robust JSON parsing; fails open (exit 0)
+# if the payload can't be parsed, so legitimate edits are never wedged.
+paths="$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+ti = data.get("tool_input", {}) or {}
+for key in ("path", "targetFile", "sourcePath", "destinationPath"):
+    val = ti.get(key)
+    if val:
+        print(val)
+' 2>/dev/null)"
+
+# No path found -> nothing to protect, allow.
+[ -z "$paths" ] && exit 0
+
+# Check each candidate path; block if any targets a governance directory.
+while IFS= read -r target_path; do
+  [ -z "$target_path" ] && continue
+  case "$target_path" in
+    */.kiro/steering/*|.kiro/steering/*|*/.kiro/hooks/*|.kiro/hooks/*)
+      echo "BLOCKED: '$target_path' is a governance file (.kiro/steering/ or .kiro/hooks/)." >&2
+      echo "These are maintained by repo owners only. Contact the maintainers if changes are needed." >&2
+      exit 2
+      ;;
+  esac
+done <<< "$paths"
+
+exit 0


### PR DESCRIPTION
…to Stop

protect-governance: was an agent-type PreToolUse hook that could only *ask* the agent to self-check and fired on every write regardless of path. Now a command hook backed by a path-based script that exits 2 to hard-block writes under .kiro/steering/ and .kiro/hooks/. Near-instant, real enforcement, and silent for all other paths. Checks every path field (incl. smart_relocate destinationPath) and fails open on unparseable input.

pre-write-conformity: demoted from per-write PreToolUse to a single Stop-time review. Deterministic standards (regions, tracking, stack naming) belong in CI and the contributor-guide is already always-on steering, so prompting on every individual write was redundant and slow.

Includes stdin-driven unit tests validated for: steering block, hooks block, normal-file allow, malformed-input fail-open, and smart_relocate destination.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
