### PR TITLE
docs(contributor-guide): document agent-container shared-utils exception

### DIFF
--- a/.kiro/steering/contributor-guide.md
+++ b/.kiro/steering/contributor-guide.md
@@ -237,6 +237,33 @@ from .constructs import MyConstruct
 - ❌ `sys.path.insert()` or path manipulation
 - CDK deployment scripts set `PYTHONPATH` automatically
 
+#### Agent containers: the shared-utils exception
+
+Code that runs **inside an AgentCore/Docker container** (e.g. `agent.py` and its
+helpers) cannot import from `shared/utils/` — the shared module lives outside the
+image build context, so `from shared.utils import ...` fails at runtime in the
+container.
+
+For container code only, the sanctioned pattern is:
+
+1. Ship a **container-local copy** named `aws_utils.py` at the demo/agent root so
+   it is inside the build context.
+2. Keep it in sync with `shared/utils/aws_utils.py` (same function names and
+   behavior). When you fix a bug in one, fix it in the other.
+3. `sys.path` manipulation to import that local copy **is allowed here** — this is
+   the one exception to the "no `sys.path.insert()`" rule above, which otherwise
+   still applies to CDK and deployment code.
+
+This keeps "use shared utilities everywhere" intact for CDK/deploy code while
+giving container code a documented, consistent path instead of per-demo
+precedent. Existing examples: `aws-services-lifecycle-tracker/agent/aws_utils.py`,
+`ai-password-reset-chatbot/agent/aws_utils.py`,
+`ai-load-test-generation-with-dlt/aws_utils.py`.
+
+> Note: hand-copied files can drift (an APAC CRIS-prefix bug once diverged
+> between copies). Until a build-time copy mechanism exists, treat syncing these
+> copies as part of any change to the shared util.
+
 **TypeScript**:
 ```typescript
 import * as cdk from 'aws-cdk-lib';


### PR DESCRIPTION
## Why
The contributor guide says to *use shared utilities everywhere* and forbids `sys.path.insert()`. But code that runs **inside an AgentCore/Docker container** (e.g. `agent.py`) can't import `shared/utils/` — it lives outside the image build context, so `from shared.utils import ...` fails at runtime.

Three demos already hit this and each worked around it the same way (hand-copied `aws_utils.py`), justifying it by **citing the previous demo as precedent**:
- `aws-services-lifecycle-tracker/agent/aws_utils.py`
- `ai-password-reset-chatbot/agent/aws_utils.py`
- `ai-load-test-generation-with-dlt/aws_utils.py` (from #97)

Undocumented precedent drifts — that's exactly how the APAC CRIS-prefix bug (fixed in #101) diverged between the shared util and a copy. This turns the tribal convention into a written rule.

## What
Adds a `#### Agent containers: the shared-utils exception` subsection to the Import Patterns section:
1. Ship a container-local `aws_utils.py` at the demo/agent root.
2. Keep it in sync with `shared/utils/aws_utils.py`.
3. `sys.path` for that local import is the **one** sanctioned exception; the rule still applies to CDK/deploy code.

Plus a note on the drift risk pending a build-time copy mechanism.

Docs-only, additive (27 lines, nothing removed).