### PR TITLE
chore: bump runtime floors to Python 3.12+ and Node.js 20+

### DIFF
--- a/.kiro/steering/contributor-guide.md
+++ b/.kiro/steering/contributor-guide.md
@@ -62,8 +62,8 @@ Why CDK:
 ### Scripting & Deployment
 
 - **PowerShell + Bash**: Must provide both for every demo
-- **Python 3.9+**: Backend services, agents, data processing
-- **TypeScript/Node.js 18+**: CDK infrastructure, frontend apps
+- **Python 3.12+**: Backend services, agents, data processing
+- **TypeScript/Node.js 20+**: CDK infrastructure, frontend apps
 
 ### Frontend Technologies
 


### PR DESCRIPTION
## Summary
Updates the `Scripting & Deployment` runtime floors in the contributor guide.

- Python `3.9+` -> `3.12+`
- TypeScript/Node.js `18+` -> `20+`

## Why
- **Node.js 18** reached community end-of-life (Apr 30, 2025) and is deprecated on AWS Lambda; the lowest supported Lambda Node runtime is now `nodejs22.x`.
- **Python 3.9** is deprecated on AWS Lambda (no security patches as of Dec 2025). Raising the floor to 3.12 keeps new demos clear of the 3.10 (Oct 2026) and 3.11 (Jun 2027) deprecations.

This keeps *new* demos starting on supported runtimes so they deploy in any account without modification.

## Scope
- Documentation/steering only. No existing demo code changed.
- A repo scan confirmed no deployed CDK stack pins a deprecated runtime today (lowest in use: `python3.11`, `NODEJS_22_X`).

## Testing
- N/A (guidance text change).