### PR TITLE
docs(contributor-guide): keep llms.txt + README demo catalog in sync

### DIFF
--- a/.kiro/steering/contributor-guide.md
+++ b/.kiro/steering/contributor-guide.md
@@ -129,6 +129,8 @@ sample-genai-ops-demos/
 5. Solution adoption tracking in CDK app file
 6. `.gitignore` including `cdk.out*`
 
+**Keep the catalog in sync.** When you add, rename, or remove a demo, update the demo catalog in both `llms.txt` (the repo's LLM-friendly index) and `README.md` so they don't drift from the actual set of demos.
+
 ### Deploy Script Exemption (`.no-deploy`)
 
 Demos that are local tools with no AWS infrastructure to deploy may opt out of deployment scripts by placing a `.no-deploy` file at the demo root. The file must contain a one-line explanation of why scripts aren't needed.


### PR DESCRIPTION
## Why
The repo now ships `llms.txt` — an [llms.txt](https://llmstxt.org/)-style index that catalogs every demo for external AI tools. It sits alongside the demo catalog in `README.md`. Both are **hand-maintained lists** and will silently drift as demos are added, renamed, or removed (we just saw a new demo branch land that will need an entry).

## What
One-line rule added to the **Required Files for Every Demo** section: when the demo set changes, update the catalog in both `llms.txt` and `README.md`.

Docs-only, additive (2 lines). Puts the upkeep obligation where contributors already look.

## Note
This is the lightweight guard. A stronger follow-up would be a CI check (extend `structure-check.yml` to fail a PR if a demo directory has no `llms.txt` entry) — happy to open that separately if maintainers want enforcement rather than convention.