### PR TITLE
Fix llms.txt drift + enforce catalog sync in CI

### DIFF
--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -142,40 +142,48 @@ jobs:
 
           exit $EXIT_CODE
 
-      - name: Check llms.txt catalog is in sync
+      - name: Check llms.txt catalog for changed demos
         run: |
-          # The llms.txt catalog is hand-maintained and drifts as demos are
-          # added/renamed/removed. Reconcile it against the actual demo set
-          # (every pillar/demo directory that ships a README.md) in BOTH
-          # directions: missing entries (demo not listed) and stale entries
-          # (listed demo no longer exists). Either fails the check.
+          # PR-SCOPED catalog check: only enforce llms.txt for demos THIS PR
+          # touches, so a contributor is never blocked by pre-existing drift
+          # someone else introduced. Rules:
+          #   - a demo README added in this PR  -> must be listed in llms.txt
+          #   - a demo README removed in this PR -> must be delisted from llms.txt
+          # Repo-wide stale/missing sweeps are handled by a separate scheduled
+          # maintainer-notification job, not this contributor gate.
           PILLARS="security cost-optimization operations-automation resilience observability"
+          PILLAR_RE="($(echo "$PILLARS" | tr ' ' '|'))"
 
-          # Actual demos: pillar/demo/README.md, two levels deep.
-          find $PILLARS -mindepth 2 -maxdepth 2 -name README.md 2>/dev/null \
-            | sort > /tmp/actual.txt
+          # Demo README paths this PR added / deleted (two levels deep only).
+          ADDED=$(git diff --name-status --diff-filter=A origin/main...HEAD \
+            | awk '{print $2}' \
+            | grep -oE "^${PILLAR_RE}/[^/]+/README\.md$" | sort -u || true)
+          REMOVED=$(git diff --name-status --diff-filter=D origin/main...HEAD \
+            | awk '{print $2}' \
+            | grep -oE "^${PILLAR_RE}/[^/]+/README\.md$" | sort -u || true)
 
-          # Catalogued demos: pillar-prefixed README.md links parsed from llms.txt.
-          # The pillar prefix naturally excludes the Overview/Optional links
-          # (README.md, CONTRIBUTING.md, workflows, etc.).
-          grep -oE "($(echo "$PILLARS" | tr ' ' '|'))/[^)]+/README\.md" llms.txt \
-            | sort -u > /tmp/listed.txt
-
-          MISSING=$(comm -23 /tmp/actual.txt /tmp/listed.txt)
-          STALE=$(comm -13 /tmp/actual.txt /tmp/listed.txt)
+          # Currently-catalogued demo links in llms.txt.
+          grep -oE "${PILLAR_RE}/[^)]+/README\.md" llms.txt | sort -u > /tmp/listed.txt
 
           RC=0
-          if [ -n "$MISSING" ]; then
-            echo "❌ Demos missing from llms.txt (add a catalog entry):"
-            echo "$MISSING" | sed 's/^/   - /'
-            RC=1
-          fi
-          if [ -n "$STALE" ]; then
-            echo "❌ Stale llms.txt entries (demo no longer exists — remove or fix):"
-            echo "$STALE" | sed 's/^/   - /'
-            RC=1
-          fi
-          if [ "$RC" -eq 0 ]; then
-            echo "✅ llms.txt catalog is in sync ($(wc -l < /tmp/actual.txt) demos)"
+          for path in $ADDED; do
+            if grep -qxF "$path" /tmp/listed.txt; then
+              echo "✅ Added demo listed in llms.txt: $path"
+            else
+              echo "❌ Added demo not in llms.txt (add a catalog entry): $path"
+              RC=1
+            fi
+          done
+          for path in $REMOVED; do
+            if grep -qxF "$path" /tmp/listed.txt; then
+              echo "❌ Removed demo still in llms.txt (delete its catalog entry): $path"
+              RC=1
+            else
+              echo "✅ Removed demo delisted from llms.txt: $path"
+            fi
+          done
+
+          if [ -z "$ADDED$REMOVED" ]; then
+            echo "No demo README added or removed in this PR — llms.txt check skipped."
           fi
           exit $RC

--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -141,3 +141,41 @@ jobs:
           done
 
           exit $EXIT_CODE
+
+      - name: Check llms.txt catalog is in sync
+        run: |
+          # The llms.txt catalog is hand-maintained and drifts as demos are
+          # added/renamed/removed. Reconcile it against the actual demo set
+          # (every pillar/demo directory that ships a README.md) in BOTH
+          # directions: missing entries (demo not listed) and stale entries
+          # (listed demo no longer exists). Either fails the check.
+          PILLARS="security cost-optimization operations-automation resilience observability"
+
+          # Actual demos: pillar/demo/README.md, two levels deep.
+          find $PILLARS -mindepth 2 -maxdepth 2 -name README.md 2>/dev/null \
+            | sort > /tmp/actual.txt
+
+          # Catalogued demos: pillar-prefixed README.md links parsed from llms.txt.
+          # The pillar prefix naturally excludes the Overview/Optional links
+          # (README.md, CONTRIBUTING.md, workflows, etc.).
+          grep -oE "($(echo "$PILLARS" | tr ' ' '|'))/[^)]+/README\.md" llms.txt \
+            | sort -u > /tmp/listed.txt
+
+          MISSING=$(comm -23 /tmp/actual.txt /tmp/listed.txt)
+          STALE=$(comm -13 /tmp/actual.txt /tmp/listed.txt)
+
+          RC=0
+          if [ -n "$MISSING" ]; then
+            echo "❌ Demos missing from llms.txt (add a catalog entry):"
+            echo "$MISSING" | sed 's/^/   - /'
+            RC=1
+          fi
+          if [ -n "$STALE" ]; then
+            echo "❌ Stale llms.txt entries (demo no longer exists — remove or fix):"
+            echo "$STALE" | sed 's/^/   - /'
+            RC=1
+          fi
+          if [ "$RC" -eq 0 ]; then
+            echo "✅ llms.txt catalog is in sync ($(wc -l < /tmp/actual.txt) demos)"
+          fi
+          exit $RC

--- a/llms.txt
+++ b/llms.txt
@@ -30,6 +30,7 @@ Each demo lives under a pillar directory and typically ships a `README.md` (depl
 - [AI Password Reset Chatbot](operations-automation/ai-password-reset-chatbot/README.md): Conversational password reset with streaming responses, session persistence, and secure Cognito integration for anonymous access
 - [AWS Services Lifecycle Tracker](operations-automation/aws-services-lifecycle-tracker/README.md): Automated monitoring and intelligent categorization of AWS service deprecations with real-time dashboard and admin interface
 - [AI Lambda Runtime Migration Assistant](operations-automation/ai-lambda-runtime-migration/README.md): Discover, assess, and transform Lambda functions running deprecated runtimes using Amazon Bedrock AgentCore and Nova 2 Lite with a React dashboard
+- [AnyCompany IT Demo Portal](operations-automation/anycompany-it-demo-portal/README.md): Multi-portal enterprise IT system simulation demonstrating AI-powered legacy system automation using Amazon Nova Act with the AgentCore Browser Tool
 
 ## Resilience
 
@@ -41,6 +42,7 @@ Each demo lives under a pillar directory and typically ships a `README.md` (depl
 - [Intelligent AWS Site-to-Site VPN Tunnel Investigation with Amazon DevOps Agent](observability/aws-site-to-site-vpn-tunnel-investigation-devops-agent/README.md): Automatically detect, investigate, and diagnose Site-to-Site VPN tunnel failures with BGP routing using Amazon DevOps Agent
 - [SaaS Status MCP Server for AWS DevOps Agent](observability/saas-status-mcp/README.md): Remote MCP server on Bedrock AgentCore giving AWS DevOps Agent real-time visibility into upstream SaaS dependency health (Snowflake, Datadog, GitHub, and 25 more)
 - [AWS Feature Relevance Notification System](observability/aws-feature-relevance-notification-system/README.md): AI-powered scoring of AWS feature announcements against registered workload profiles using Bedrock, with Slack notifications for high-relevance updates
+- [Proactive Health Event Impact Analyzer](observability/proactive-health-event-impact-analyzer/README.md): Use AWS DevOps Agent to triage AWS Health events, assess their impact, and route multi-team notifications automatically
 
 ## Optional
 


### PR DESCRIPTION
Backs the catalog-upkeep rule from #107 with a drift fix + a **fair, PR-scoped** CI check.

## Two changes

**1. Fix existing drift in `llms.txt`** (docs)
Two shipped demos were missing from the catalog:
- `observability/proactive-health-event-impact-analyzer`
- `operations-automation/anycompany-it-demo-portal`

Added under their pillar sections. Catalog now matches all 18 demos.

**2. PR-scoped catalog check in `structure-check.yml`** (CI)
Only enforces `llms.txt` for demos **this PR touches**:
- a demo README **added** in the PR → must be listed
- a demo README **removed** in the PR → must be delisted

Pre-existing/unrelated drift does **not** block the PR — a contributor is never punished for a mess someone else left. (Earlier draft did a whole-repo reconcile, which would unfairly fail an unrelated PR; reworked after review.)

## Follow-up (separate PR)
Repo-wide **stale** sweeps belong to maintainers, not the contributor gate. Planned: a scheduled workflow that opens/updates a single GitHub issue when the catalog drifts, auto-closing when clean — poke maintainers without blocking anyone.

## Testing (local)
| Scenario | Result |
|---|---|
| PR adds demo, listed | ✅ pass |
| PR adds demo, not listed | ✅ fail |
| PR removes demo, entry lingers | ✅ fail |
| PR removes demo, delisted | ✅ pass |
| Unrelated pre-existing drift, no demo change | ✅ pass (not blocked) |

YAML validated. Existing structure checks unchanged.