### PR TITLE
ci: scheduled llms.txt catalog drift monitor (maintainer poke)

### DIFF
--- a/.github/workflows/catalog-drift-monitor.yml
+++ b/.github/workflows/catalog-drift-monitor.yml
@@ -1,0 +1,101 @@
+name: Catalog Drift Monitor
+
+# Repo-wide llms.txt catalog health check for MAINTAINERS (not a contributor gate).
+# The PR-scoped check in structure-check.yml keeps a contributor's own changes
+# honest; this scheduled job hunts down pre-existing / accumulated drift across
+# the whole catalog and pokes maintainers via a single, self-updating issue.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"   # every Monday 08:00 UTC
+  workflow_dispatch: {}     # allow manual runs
+
+permissions:
+  contents: read
+  issues: write             # needed to open/update/close the drift issue
+
+jobs:
+  catalog-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reconcile llms.txt against the demo set
+        id: reconcile
+        run: |
+          PILLARS="security cost-optimization operations-automation resilience observability"
+          PILLAR_RE="($(echo "$PILLARS" | tr ' ' '|'))"
+
+          # Actual demos: pillar/demo/README.md (two levels deep).
+          find $PILLARS -mindepth 2 -maxdepth 2 -name README.md 2>/dev/null \
+            | sort > /tmp/actual.txt
+          # Catalogued demo links in llms.txt (pillar prefix excludes non-demo links).
+          grep -oE "${PILLAR_RE}/[^)]+/README\.md" llms.txt | sort -u > /tmp/listed.txt
+
+          MISSING=$(comm -23 /tmp/actual.txt /tmp/listed.txt)
+          STALE=$(comm -13 /tmp/actual.txt /tmp/listed.txt)
+
+          BODY=""
+          if [ -n "$MISSING" ]; then
+            BODY="${BODY}### Demos missing from llms.txt (not listed)\n"
+            BODY="${BODY}$(echo "$MISSING" | sed 's/^/- /')\n\n"
+          fi
+          if [ -n "$STALE" ]; then
+            BODY="${BODY}### Stale llms.txt entries (demo no longer exists)\n"
+            BODY="${BODY}$(echo "$STALE" | sed 's/^/- /')\n\n"
+          fi
+
+          if [ -z "$MISSING$STALE" ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "✅ Catalog in sync ($(wc -l < /tmp/actual.txt) demos)"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            {
+              echo "body<<$EOF"
+              printf "%b" "$BODY"
+              echo "$EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "⚠️ Catalog drift detected"
+            printf "%b" "$BODY"
+          fi
+
+      - name: Open, update, or close the drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DRIFT: ${{ steps.reconcile.outputs.drift }}
+          DRIFT_BODY: ${{ steps.reconcile.outputs.body }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          LABEL="catalog-drift"
+          TITLE="llms.txt catalog drift detected"
+
+          # Ensure the label exists (idempotent).
+          gh label create "$LABEL" --repo "$REPO" \
+            --color d93f0b --description "llms.txt catalog is out of sync with the demo set" \
+            2>/dev/null || true
+
+          # Find an existing open drift issue (dedup — never spam new issues).
+          EXISTING=$(gh issue list --repo "$REPO" --state open --label "$LABEL" \
+            --json number --jq '.[0].number' 2>/dev/null || true)
+
+          if [ "$DRIFT" = "true" ]; then
+            FULL_BODY=$(printf "%b\n\n---\n_Detected by the Catalog Drift Monitor ([run](%s)). cc @bquintas @benlec. This issue auto-updates on the next run and auto-closes when the catalog is back in sync._" "$DRIFT_BODY" "$RUN_URL")
+            if [ -n "$EXISTING" ]; then
+              echo "Updating existing drift issue #$EXISTING"
+              gh issue edit "$EXISTING" --repo "$REPO" --body "$FULL_BODY"
+              gh issue comment "$EXISTING" --repo "$REPO" --body "Drift still present as of $(date -u +%Y-%m-%dT%H:%MZ). See updated list above."
+            else
+              echo "Opening new drift issue"
+              gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" --body "$FULL_BODY"
+            fi
+          else
+            if [ -n "$EXISTING" ]; then
+              echo "Catalog back in sync — closing issue #$EXISTING"
+              gh issue comment "$EXISTING" --repo "$REPO" --body "✅ Catalog is back in sync as of $(date -u +%Y-%m-%dT%H:%MZ). Closing automatically."
+              gh issue close "$EXISTING" --repo "$REPO"
+            else
+              echo "No drift and no open issue — nothing to do."
+            fi
+          fi


### PR DESCRIPTION
Follow-up to #108. Moves repo-wide **stale/missing** catalog detection out of the contributor PR gate and into a maintainer-facing scheduled job.

## Why
#108 makes the PR gate **PR-scoped** (a contributor is only responsible for demos their PR touches). But repo-wide drift — e.g. a stale entry left when someone removed a demo — still deserves attention. That's a maintainer chore, not a contributor gate. This job handles it without blocking anyone.

## What it does
`catalog-drift-monitor.yml`:
- **Schedule:** weekly (Mon 08:00 UTC) + manual `workflow_dispatch`.
- Reconciles `llms.txt` against the demo set in both directions (missing + stale).
- **Pokes maintainers via one self-updating issue:**
  - opens a `catalog-drift` issue when drift appears (cc @bquintas @benlec, per CODEOWNERS on `.github/`)
  - updates the *same* issue on later runs — idempotent, no duplicate spam
  - auto-closes when the catalog is back in sync
- Permissions: `issues: write`, `contents: read`.

## Testing
Reconcile logic verified locally under bash (the CI shell): against this branch (pre-#108 `main`) it correctly reports the 2 known-missing demos; against a synced tree it reports none. The issue open/update/close path uses standard `gh` calls with label-based dedup.

## Sequencing note
Best merged **after** #108 (the catalog fix) so the monitor starts from a clean, in-sync state. If it runs before, it'll simply open a drift issue for the 2 missing demos and auto-close it once #108 lands.