### PR TITLE
fix(observability): re-land health analyzer hardening, addressing PR #106 review

### DIFF
--- a/observability/proactive-health-event-impact-analyzer/README.md
+++ b/observability/proactive-health-event-impact-analyzer/README.md
@@ -1,4 +1,6 @@
-# Use AWS DevOps Agent to triage and route AWS Health event impact
+# Proactive AWS Health Event Impact Analyzer
+
+## Use AWS DevOps Agent to triage and route AWS Health event impact
 
 > **This is a sample application** demonstrating how to build automated AWS Health event impact assessment and multi-team notification routing using AWS DevOps Agent. Use it as a reference architecture or starting point for your own implementation.
 

--- a/observability/proactive-health-event-impact-analyzer/deploy-all.ps1
+++ b/observability/proactive-health-event-impact-analyzer/deploy-all.ps1
@@ -103,11 +103,20 @@ Write-Host "  Deployment Script" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 
 if (-not $SkipSetup) {
-    # Use shared prerequisites if available (monorepo), otherwise inline checks
+    # Use shared prerequisites if available (monorepo), otherwise inline checks.
+    # The shared script validates the AWS CLI, credentials, region, and — via
+    # -RequiredService agentcore — that AWS DevOps Agent (AgentCore) is actually
+    # reachable in the resolved region, then sets $global:AWS_REGION / AWS_ACCOUNT_ID
+    # / AWS_ARN. The wizard reuses those instead of re-checking, so prerequisites
+    # are validated exactly once.
     $sharedPrereqs = Join-Path $ScriptDir "..\..\shared\scripts\check-prerequisites.ps1"
     if (Test-Path $sharedPrereqs) {
-        & $sharedPrereqs -RequiredService "bedrock" -MinAwsCliVersion "2.34.20"
+        & $sharedPrereqs -RequiredService "agentcore" -MinAwsCliVersion "2.34.20"
         $region = $global:AWS_REGION
+        # Hand the validated context to the wizard so it does not re-run these checks.
+        $env:AWS_REGION = $global:AWS_REGION
+        $env:AWS_ACCOUNT_ID = $global:AWS_ACCOUNT_ID
+        $env:AWS_ARN = $global:AWS_ARN
     } else {
         $region = Test-Prerequisites
     }
@@ -147,9 +156,9 @@ Write-Host "Launching interactive setup wizard..." -ForegroundColor Cyan
 Write-Host "The wizard will guide you through DevOps Agent configuration and CDK deployment." -ForegroundColor Gray
 Write-Host ""
 
-Push-Location $ScriptDir
+Push-Location (Join-Path $ScriptDir "scripts")
 try {
-    npx ts-node scripts/setup-wizard.ts
+    npx ts-node setup-wizard.ts
     $wizardExitCode = $LASTEXITCODE
 } finally {
     Pop-Location

--- a/observability/proactive-health-event-impact-analyzer/deploy-all.sh
+++ b/observability/proactive-health-event-impact-analyzer/deploy-all.sh
@@ -117,11 +117,18 @@ echo "  Deployment Script"
 echo "========================================"
 
 if [ "$SKIP_SETUP" = false ]; then
-    # Use shared prerequisites if available (monorepo), otherwise inline checks
+    # Use shared prerequisites if available (monorepo), otherwise inline checks.
+    # The shared script validates the AWS CLI, credentials, region, and — via
+    # --required-service agentcore — that AWS DevOps Agent (AgentCore) is actually
+    # reachable in the resolved region (it calls bedrock-agentcore-control), then
+    # exports AWS_REGION / AWS_ACCOUNT_ID / AWS_ARN. The wizard reuses those exports
+    # instead of re-checking, so prerequisites are validated exactly once.
     SHARED_PREREQS="$SCRIPT_DIR/../../shared/scripts/check-prerequisites.sh"
     if [ -f "$SHARED_PREREQS" ]; then
-        source "$SHARED_PREREQS" bedrock 2.34.20
+        source "$SHARED_PREREQS" --required-service agentcore --min-aws-cli-version 2.34.20
         region=$AWS_REGION
+        # Hand the validated context to the wizard so it does not re-run these checks.
+        export AWS_REGION AWS_ACCOUNT_ID AWS_ARN
     else
         check_prerequisites
         region=$(get_aws_region)
@@ -151,9 +158,10 @@ echo "Launching interactive setup wizard..."
 echo "The wizard will guide you through DevOps Agent configuration and CDK deployment."
 echo ""
 
-cd "$SCRIPT_DIR"
-npx ts-node scripts/setup-wizard.ts
+cd "$SCRIPT_DIR/scripts"
+npx ts-node setup-wizard.ts
 wizard_exit_code=$?
+cd "$SCRIPT_DIR"
 
 if [ $wizard_exit_code -ne 0 ]; then
     echo ""

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/investigation-callback/index.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/investigation-callback/index.ts
@@ -1,5 +1,5 @@
 import { EventBridgeEvent } from 'aws-lambda';
-import { DynamoDBClient, ScanCommand, DeleteItemCommand } from '@aws-sdk/client-dynamodb';
+import { DynamoDBClient, GetItemCommand, ScanCommand, DeleteItemCommand } from '@aws-sdk/client-dynamodb';
 import { SFNClient, SendTaskSuccessCommand, SendTaskFailureCommand } from '@aws-sdk/client-sfn';
 import {
   DevOpsAgentClient,
@@ -118,8 +118,8 @@ export const handler = async (
       console.log(`Task failure sent for investigation ${correlationKey}: ${errorMessage}`);
     }
 
-    // Clean up the token record
-    await deleteTaskToken(correlationKey);
+    // Clean up the exact token record we resolved
+    await deleteTaskToken(taskTokenRecord.investigationId);
   } catch (error) {
     console.error(`Failed to send task response for ${correlationKey}:`, error);
     throw error;
@@ -191,16 +191,32 @@ async function getAgentAnalysis(agentSpaceId: string, executionId: string): Prom
 
 // ─── Correlation ────────────────────────────────────────────────────────────
 
+/** Extracts the value of a `[PREFIX:value]` tag from text, or null if absent/empty. */
+function extractTag(text: string, prefix: string): string | null {
+  const start = text.indexOf(prefix);
+  if (start === -1) return null;
+  const valueStart = start + prefix.length;
+  const end = text.indexOf(']', valueStart);
+  if (end === -1) return null;
+  return text.substring(valueStart, end).trim() || null;
+}
+
 /**
  * Extracts the correlation key from the first journal message.
  *
- * The Investigation Trigger embeds correlation data in two places:
- * 1. Description starts with: [CORRELATION_ID:{healthEventArn}]
- * 2. Title starts with: [{incidentId}] AWS Health: ...
+ * The Investigation Trigger embeds correlation data in three places:
+ * 1. Description: [INVESTIGATION_ID:{incidentId}]  — unique per investigation
+ * 2. Description: [CORRELATION_ID:{healthEventArn}] — shared across investigations for one event
+ * 3. Title: [{incidentId}] AWS Health: ...
  *
- * Strategy:
- * - Primary: extract healthEventArn from [CORRELATION_ID:...] → search DynamoDB by healthEventId
- * - Fallback: extract incidentId from title [{incidentId}] → search DynamoDB by investigationId
+ * Strategy (most-specific first):
+ * - Primary: incidentId from [INVESTIGATION_ID:...] → keyed lookup by investigationId (unique).
+ * - Legacy: healthEventArn from [CORRELATION_ID:...] → scan by healthEventId (NOT unique; first match).
+ * - Fallback: incidentId from title [{incidentId}] → lookup by investigationId.
+ *
+ * The healthEventArn is shared by every investigation spawned for the same Health event,
+ * so it cannot disambiguate concurrent investigations. INVESTIGATION_ID is preferred
+ * because it maps 1:1 to a token-table row.
  */
 function extractCorrelationKey(message: MessageContent): string | null {
   if (message.role !== 'user') {
@@ -212,34 +228,26 @@ function extractCorrelationKey(message: MessageContent): string | null {
     .map(c => c.text!)
     .join(' ');
 
-  // Primary: [CORRELATION_ID:{healthEventArn}] in description
-  const prefix = '[CORRELATION_ID:';
-  const startIdx = textContent.indexOf(prefix);
-  if (startIdx !== -1) {
-    const valueStart = startIdx + prefix.length;
-    const endIdx = textContent.indexOf(']', valueStart);
-    if (endIdx !== -1) {
-      const correlationId = textContent.substring(valueStart, endIdx).trim();
-      if (correlationId) {
-        console.log(`Correlation via CORRELATION_ID tag: ${correlationId}`);
-        return `arn:${correlationId}`;
-      }
-    }
+  // Primary: [INVESTIGATION_ID:{incidentId}] — unique per investigation.
+  const investigationId = extractTag(textContent, '[INVESTIGATION_ID:');
+  if (investigationId) {
+    console.log(`Correlation via INVESTIGATION_ID tag: ${investigationId}`);
+    return investigationId;
+  }
+
+  // Legacy: [CORRELATION_ID:{healthEventArn}] — kept for rows created before
+  // INVESTIGATION_ID tagging. Returns an `arn:`-prefixed key handled by the scan path.
+  const correlationId = extractTag(textContent, '[CORRELATION_ID:');
+  if (correlationId) {
+    console.log(`Correlation via CORRELATION_ID tag: ${correlationId}`);
+    return `arn:${correlationId}`;
   }
 
   // Fallback: [{incidentId}] in title (format: TITLE: [{incidentId}] AWS Health: ...)
-  const titlePrefix = 'TITLE: [';
-  const titleIdx = textContent.indexOf(titlePrefix);
-  if (titleIdx !== -1) {
-    const idStart = titleIdx + titlePrefix.length;
-    const idEnd = textContent.indexOf(']', idStart);
-    if (idEnd !== -1) {
-      const incidentId = textContent.substring(idStart, idEnd).trim();
-      if (incidentId && incidentId.startsWith('health-')) {
-        console.log(`Correlation via title incidentId: ${incidentId}`);
-        return incidentId;
-      }
-    }
+  const titleIncidentId = extractTag(textContent, 'TITLE: [');
+  if (titleIncidentId && titleIncidentId.startsWith('health-')) {
+    console.log(`Correlation via title incidentId: ${titleIncidentId}`);
+    return titleIncidentId;
   }
 
   console.warn('No correlation key found in message text');
@@ -257,14 +265,20 @@ function buildOutput(
   agentAnalysis: string | null,
   investigationLink: string
 ): object {
-  const priority = detail.data.priority || 'MEDIUM';
+  // The task priority (derived from the Health event category at intake) is only a
+  // fallback here. The reported severity should reflect the agent's own conclusion.
+  const taskPriority = detail.data.priority || 'MEDIUM';
 
   if (!agentAnalysis) {
+    // Degraded case: the investigation completed but we could not retrieve its
+    // analysis. This is intentionally NOT downgraded to LOW — we keep the task
+    // priority so the missing-analysis case still surfaces an OpsItem for a human
+    // to review, rather than being silently skipped by the workflow's LOW gate.
     return {
       investigationStatus: 'NO_IMPACT',
       summary: 'Investigation completed but no analysis available',
       rootCause: null,
-      priority,
+      priority: taskPriority,
       findings: [],
       recommendations: [],
       investigationLink,
@@ -272,7 +286,15 @@ function buildOutput(
   }
 
   // Parse the agent's markdown analysis to extract structured data
-  const parsed = parseAgentAnalysis(agentAnalysis, priority);
+  const parsed = parseAgentAnalysis(agentAnalysis, taskPriority);
+
+  // Severity = the highest per-workload severity the agent assigned in
+  // "## Key Findings". Fall back to the task priority only when impact exists but
+  // no severity word was parsed. No impact → LOW, so the workflow's priority gate
+  // routes it to the no-OpsItem branch.
+  const priority = parsed.hasImpact
+    ? (parsed.overallSeverity || taskPriority)
+    : 'LOW';
 
   return {
     investigationStatus: parsed.hasImpact ? 'IMPACT_DETECTED' : 'NO_IMPACT',
@@ -289,10 +311,11 @@ function buildOutput(
  * Parses the agent's markdown analysis into structured findings and recommendations.
  * The agent produces rich markdown with headers, tables, and bullet points.
  */
-function parseAgentAnalysis(analysis: string, priority: string): {
+function parseAgentAnalysis(analysis: string, fallbackPriority: string): {
   hasImpact: boolean;
   summary: string;
   rootCause: string | null;
+  overallSeverity: string | null;
   findings: Array<{ description: string; severity: string; affectedResources: string[]; owningTeam?: string }>;
   recommendations: Array<{ description: string; priority: string }>;
 } {
@@ -300,6 +323,7 @@ function parseAgentAnalysis(analysis: string, priority: string): {
     hasImpact: false,
     summary: '',
     rootCause: null as string | null,
+    overallSeverity: null as string | null,
     findings: [] as Array<{ description: string; severity: string; affectedResources: string[]; owningTeam?: string }>,
     recommendations: [] as Array<{ description: string; priority: string }>,
   };
@@ -318,18 +342,28 @@ function parseAgentAnalysis(analysis: string, priority: string): {
   const answersSection = analysis.match(/## Answers to Your Questions([\s\S]*?)$/);
   const contentToSearch = findingsSection?.[1] || answersSection?.[1] || analysis;
 
+  // Severities of ALL findings, used to compute the overall severity. Kept
+  // separate from result.findings, which is capped at 5 for display — otherwise
+  // a CRITICAL workload listed 6th would be dropped and the overall severity
+  // (and the resulting OpsItem) would be under-reported.
+  const allFindingSeverities: string[] = [];
   const bulletFindings = contentToSearch.match(/[-•*]\s+\*\*(.+?)\*\*[:\s]*(.+)/g);
   if (bulletFindings) {
-    for (const bullet of bulletFindings.slice(0, 5)) {
+    bulletFindings.forEach((bullet, i) => {
       const match = bullet.match(/[-•*]\s+\*\*(.+?)\*\*[:\s]*(.*)/);
-      if (match) {
+      if (!match) return;
+      // The agent writes the impact severity in the bullet detail
+      // ("- **web-tier**: HIGH — ..."); use it, not the intake priority.
+      const severity = parseSeverity(match[2]) || fallbackPriority;
+      allFindingSeverities.push(severity);
+      if (i < 5) {
         result.findings.push({
           description: `${match[1]}: ${match[2]}`.trim(),
-          severity: priority,
+          severity,
           affectedResources: [],
         });
       }
-    }
+    });
   }
 
   // Extract recommendations from priority tables or numbered lists
@@ -398,10 +432,14 @@ function parseAgentAnalysis(analysis: string, priority: string): {
   if (result.findings.length === 0 && result.hasImpact) {
     result.findings.push({
       description: result.summary.substring(0, 200),
-      severity: priority,
+      severity: fallbackPriority,
       affectedResources: [],
     });
+    allFindingSeverities.push(fallbackPriority);
   }
+
+  // Overall severity = the highest severity across ALL findings (the agent's conclusion).
+  result.overallSeverity = highestSeverity(allFindingSeverities);
 
   return result;
 }
@@ -411,70 +449,81 @@ function mapPriority(p: string): string {
   return map[p] || 'MEDIUM';
 }
 
+// Severity ranking used to pick the overall (highest) investigation severity.
+const SEVERITY_RANK: Record<string, number> = { CRITICAL: 4, HIGH: 3, MEDIUM: 2, LOW: 1, MINIMAL: 0 };
+
+/**
+ * Extracts the impact-severity word the agent wrote in a "## Key Findings"
+ * bullet (e.g. "- **web-tier**: HIGH — ..."). Returns null when none is present.
+ */
+function parseSeverity(text: string): string | null {
+  // Per the skill's "## Key Findings" format the severity leads the bullet detail
+  // ("<SEVERITY> — <statement>"), so only accept a severity word at the start
+  // (after optional markdown/whitespace). This avoids picking up a severity word
+  // later in the sentence (e.g. "LOW baseline, escalates to CRITICAL under load").
+  const m = text.trim().toUpperCase().match(/^[*_\s]*(CRITICAL|HIGH|MEDIUM|LOW|MINIMAL)\b/);
+  return m ? m[1] : null;
+}
+
+/** Returns the highest-ranked severity in the list, or null if the list is empty. */
+function highestSeverity(severities: string[]): string | null {
+  let best: string | null = null;
+  for (const s of severities) {
+    if (best === null || (SEVERITY_RANK[s] ?? -1) > (SEVERITY_RANK[best] ?? -1)) {
+      best = s;
+    }
+  }
+  return best;
+}
+
 // ─── DynamoDB Operations ────────────────────────────────────────────────────
 
-async function findTaskToken(correlationKey: string): Promise<{ taskToken: string; healthEventId: string } | null> {
-  // If it's an ARN-based lookup, search by healthEventId
-  if (correlationKey.startsWith('arn:')) {
-    const healthEventArn = correlationKey.replace('arn:', '');
-    console.log(`Searching DynamoDB by healthEventId: ${healthEventArn}`);
-    const { Items } = await dynamoClient.send(new ScanCommand({
+async function findTaskToken(correlationKey: string): Promise<{ taskToken: string; investigationId: string } | null> {
+  // Preferred path: the key IS the unique investigationId (token table partition
+  // key) → a single, unambiguous GetItem. No Scan, no first-match ambiguity.
+  if (!correlationKey.startsWith('arn:')) {
+    const { Item } = await dynamoClient.send(new GetItemCommand({
       TableName: TASK_TOKEN_TABLE,
-      FilterExpression: 'healthEventId = :arn',
-      ExpressionAttributeValues: {
-        ':arn': { S: healthEventArn },
-      },
+      Key: { investigationId: { S: correlationKey } },
     }));
-
-    if (Items && Items.length > 0) {
-      return {
-        taskToken: Items[0].taskToken.S!,
-        healthEventId: Items[0].healthEventId?.S || '',
-      };
+    if (Item?.taskToken?.S) {
+      return { taskToken: Item.taskToken.S, investigationId: correlationKey };
     }
     return null;
   }
 
-  // Direct lookup by investigationId
+  // Legacy fallback for rows written before INVESTIGATION_ID tagging: scan by
+  // healthEventId. This is NOT unique across concurrent investigations for the
+  // same Health event and can only return an arbitrary match — new investigations
+  // never reach this path.
+  const healthEventArn = correlationKey.replace('arn:', '');
+  console.log(`Searching DynamoDB by healthEventId (legacy fallback): ${healthEventArn}`);
   const { Items } = await dynamoClient.send(new ScanCommand({
     TableName: TASK_TOKEN_TABLE,
-    FilterExpression: 'investigationId = :id',
+    FilterExpression: 'healthEventId = :arn',
     ExpressionAttributeValues: {
-      ':id': { S: correlationKey },
+      ':arn': { S: healthEventArn },
     },
   }));
-
-  if (Items && Items.length > 0) {
+  if (Items && Items.length > 0 && Items[0].investigationId?.S) {
     return {
       taskToken: Items[0].taskToken.S!,
-      healthEventId: Items[0].healthEventId?.S || '',
+      investigationId: Items[0].investigationId.S,
     };
   }
-
   return null;
 }
 
-async function deleteTaskToken(correlationKey: string): Promise<void> {
-  if (correlationKey.startsWith('arn:')) {
-    const healthEventArn = correlationKey.replace('arn:', '');
-    const { Items } = await dynamoClient.send(new ScanCommand({
-      TableName: TASK_TOKEN_TABLE,
-      FilterExpression: 'healthEventId = :arn',
-      ExpressionAttributeValues: {
-        ':arn': { S: healthEventArn },
-      },
-    }));
-    if (Items && Items.length > 0 && Items[0].investigationId?.S) {
-      await dynamoClient.send(new DeleteItemCommand({
-        TableName: TASK_TOKEN_TABLE,
-        Key: { investigationId: { S: Items[0].investigationId.S } },
-      }));
-    }
-    return;
-  }
-
+/**
+ * Deletes the token row by its exact investigationId (the one resolved by
+ * findTaskToken). Deleting the precise row we just consumed avoids the previous
+ * re-scan, which could delete a different row than the one that was resolved
+ * when multiple rows shared a healthEventId.
+ */
+async function deleteTaskToken(investigationId: string): Promise<void> {
+  if (!investigationId) return;
   await dynamoClient.send(new DeleteItemCommand({
     TableName: TASK_TOKEN_TABLE,
-    Key: { investigationId: { S: correlationKey } },
+    Key: { investigationId: { S: investigationId } },
   }));
 }

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/investigation-trigger/index.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/investigation-trigger/index.ts
@@ -68,8 +68,12 @@ export const handler = async (event: TriggerInput): Promise<void> => {
 
   console.log(`Using agent space: ${agentSpace.spaceName || 'default'} (account: ${healthEvent.sourceAccountId || 'local'})`);
 
-  // Build the investigation request for DevOps Agent webhook
-  const incidentId = `health-${healthEvent.service}-${Date.now()}`;
+  // Build the investigation request for DevOps Agent webhook.
+  // The random suffix guarantees a unique investigationId even when two
+  // triggers fire in the same millisecond for the same event (e.g. duplicate
+  // EventBridge deliveries), so concurrent investigations never share a
+  // token-table partition key.
+  const incidentId = `health-${healthEvent.service}-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
 
   const maintenanceWindow = healthEvent.startTime && healthEvent.endTime
     ? `${healthEvent.startTime} to ${healthEvent.endTime}`
@@ -89,7 +93,7 @@ export const handler = async (event: TriggerInput): Promise<void> => {
     action: 'created' as const,
     priority: mapCategoryToPriority(healthEvent.category),
     title: `[${incidentId}] AWS Health: ${healthEvent.service} ${healthEvent.eventType} in ${healthEvent.region}`,
-    description: buildDescription(healthEvent, maintenanceWindow, jiraConfig),
+    description: buildDescription(healthEvent, maintenanceWindow, jiraConfig, incidentId),
     timestamp: new Date().toISOString(),
     service: healthEvent.service,
     data: {
@@ -197,7 +201,7 @@ function mapCategoryToPriority(category: string): 'CRITICAL' | 'HIGH' | 'MEDIUM'
   }
 }
 
-function buildDescription(healthEvent: HealthEvent, maintenanceWindow: string, jiraConfig: JiraConfig | null): string {
+function buildDescription(healthEvent: HealthEvent, maintenanceWindow: string, jiraConfig: JiraConfig | null, incidentId: string): string {
   const resourceList = healthEvent.affectedResources
     .map(r => `  - ${r.resourceId} (${r.status})`)
     .join('\n');
@@ -214,6 +218,7 @@ function buildDescription(healthEvent: HealthEvent, maintenanceWindow: string, j
     : '';
 
   return `[CORRELATION_ID:${healthEvent.eventId}]
+[INVESTIGATION_ID:${incidentId}]
 ${jiraTag}
 AWS Health Event detected. Please investigate the impact on our workloads.
 

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/event-ingestion.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/event-ingestion.ts
@@ -103,22 +103,13 @@ export class EventIngestion extends Construct {
       maxEventAge: cdk.Duration.hours(24),
     }));
 
-    // Additional rule for scheduled changes specifically
-    const scheduledChangeRule = new events.Rule(this, 'ScheduledChangeRule', {
-      ruleName: 'health-event-analyzer-scheduled',
-      description: 'Captures scheduled AWS Health maintenance events',
-      eventPattern: {
-        source: ['aws.health'],
-        detailType: ['AWS Health Event'],
-        detail: {
-          eventTypeCategory: ['scheduledChange'],
-        },
-      },
-    });
-
-    scheduledChangeRule.addTarget(new targets.LambdaFunction(this.eventRouter, {
-      retryAttempts: 185,
-      maxEventAge: cdk.Duration.hours(24),
-    }));
+    // Note: scheduledChange-category events are already captured by
+    // HealthEventRule above (detailType 'AWS Health Event' with no
+    // eventTypeCategory filter). A separate rule scoped to
+    // detail.eventTypeCategory: ['scheduledChange'] would be a strict subset
+    // of that pattern and, since it would target the same Event Router Lambda,
+    // would deliver every scheduledChange event to the router twice — starting
+    // two identical Step Functions executions per event. No such rule is
+    // registered here to keep each Health event to a single investigation.
   }
 }

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/investigation-workflow.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/investigation-workflow.ts
@@ -54,6 +54,17 @@ export class InvestigationWorkflow extends Construct {
       ? logs.RetentionDays.THREE_MONTHS
       : logs.RetentionDays.TWO_WEEKS;
 
+    // Local esbuild bundling (esbuild is a devDependency), never Docker.
+    //
+    // Cross-platform note: NodejsFunction local bundling must NOT shell out to a
+    // host shell. aws-cdk-lib < 2.246.0 assembled the esbuild invocation as a
+    // command string and ran it through a shell (cmd/powershell on Windows),
+    // which fails on machines without powershell on PATH ("spawnSync
+    // powershell.exe ENOENT") and is otherwise non-deterministic across
+    // platforms. aws-cdk-lib >= 2.246.0 executes esbuild via array-based
+    // spawnSync with no shell, so bundling is deterministic on Windows, macOS,
+    // and Linux. The floor is pinned in infrastructure/cdk/package.json; do not
+    // lower it.
     const bundlingOptions = {
       forceDockerBundling: false,
       externalModules: ['@aws-sdk/*'],
@@ -451,8 +462,10 @@ export class InvestigationWorkflow extends Construct {
       timeToLiveAttribute: 'ttl',
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      deletionProtection: false,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      // Production protects the token table from accidental deletion and retains
+      // it on stack removal; non-production stays disposable for easy teardown.
+      deletionProtection: isProduction,
+      removalPolicy: isProduction ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
     });
 
     tokenTable.grantReadWriteData(investigationTrigger);

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/notification.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/notification.ts
@@ -46,8 +46,10 @@ export class Notification extends Construct {
       partitionKey: { name: 'teamId', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      deletionProtection: false,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      // Production protects the table from accidental deletion and retains it on
+      // stack removal; non-production stays disposable for easy teardown.
+      deletionProtection: isProduction,
+      removalPolicy: isProduction ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
     });
 
     // Agent spaces routing table — maps AWS account IDs to DevOps Agent spaces
@@ -57,8 +59,10 @@ export class Notification extends Construct {
       partitionKey: { name: 'accountId', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
-      deletionProtection: false,
-      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      // Production protects the table from accidental deletion and retains it on
+      // stack removal; non-production stays disposable for easy teardown.
+      deletionProtection: isProduction,
+      removalPolicy: isProduction ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
     });
   }
 }

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/health-event-analyzer-stack.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/health-event-analyzer-stack.ts
@@ -157,9 +157,19 @@ export class HealthEventAnalyzerStack extends cdk.Stack {
       sid: 'DenyInsecureTransport',
       effect: iam.Effect.DENY,
       principals: [new iam.AnyPrincipal()],
+      // SNS resource policies don't accept the sns:* wildcard, so the topic-scoped
+      // actions are enumerated to deny any non-TLS request (Req 14.3, 4.1). Only
+      // the 8 actions valid in an SNS resource policy may be used here — actions
+      // like sns:Unsubscribe / sns:Receive are rejected by SNS at deploy time
+      // ("Policy statement action out of service scope").
       actions: [
         'sns:Publish',
         'sns:Subscribe',
+        'sns:GetTopicAttributes',
+        'sns:SetTopicAttributes',
+        'sns:ListSubscriptionsByTopic',
+        'sns:AddPermission',
+        'sns:RemovePermission',
       ],
       resources: [notification.topic.topicArn],
       conditions: {
@@ -173,6 +183,9 @@ export class HealthEventAnalyzerStack extends cdk.Stack {
       sid: 'RestrictSubscriptions',
       effect: iam.Effect.ALLOW,
       principals: [new iam.AccountPrincipal(this.account)],
+      // Only the owning account may subscribe to the topic (Req 14.4).
+      // Note: sns:Unsubscribe is NOT valid in an SNS resource policy (SNS rejects
+      // it with "action out of service scope"), so only sns:Subscribe is scoped here.
       actions: ['sns:Subscribe'],
       resources: [notification.topic.topicArn],
     }));

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/package.json
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/package.json
@@ -16,7 +16,7 @@
     "@aws-sdk/client-ssm": "^3.1063.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.0",
-    "aws-cdk": "^2.150.0",
+    "aws-cdk": "^2.1006.0",
     "esbuild": "^0.28.0",
     "fast-check": "^4.8.0",
     "jest": "^29.7.0",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-devops-agent": "^3.1053.0",
-    "aws-cdk-lib": "^2.150.0",
+    "aws-cdk-lib": "^2.246.0",
     "cdk-nag": "^2.38.2",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.21"

--- a/observability/proactive-health-event-impact-analyzer/scripts/package.json
+++ b/observability/proactive-health-event-impact-analyzer/scripts/package.json
@@ -1,5 +1,7 @@
 {
   "devDependencies": {
-    "@types/node": "^25.9.1"
+    "@types/node": "^25.9.1",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.4.5"
   }
 }

--- a/observability/proactive-health-event-impact-analyzer/scripts/setup-wizard.ts
+++ b/observability/proactive-health-event-impact-analyzer/scripts/setup-wizard.ts
@@ -288,16 +288,31 @@ const SSM_PARAM_JIRA_PROJECT_KEY = '/health-analyzer/jira/projectKey';
 const SSM_PARAM_JIRA_ISSUE_TYPE = '/health-analyzer/jira/issueType';
 const SSM_PARAM_JIRA_SITE_URL = '/health-analyzer/jira/siteUrl';
 
-// ─── Supported Regions ──────────────────────────────────────────────────────
+// ─── Region Resolution ──────────────────────────────────────────────────────
 
-const SUPPORTED_REGIONS = [
-  'us-east-1',
-  'us-west-2',
-  'ap-southeast-2',
-  'ap-northeast-1',
-  'eu-central-1',
-  'eu-west-1',
-];
+// The wizard does NOT hardcode a region shortlist. AWS DevOps Agent (AgentCore)
+// availability shifts over time, so a static list rots and is inaccurate. Instead
+// we resolve the region exactly like the shared deploy scripts and the shared
+// prerequisites check do — environment first, then the AWS CLI's configured
+// region, then a safe default — and let the shared prerequisites check
+// (`check-prerequisites --required-service agentcore`) prove the service is
+// actually reachable in that region by calling it. When invoked through the
+// shared deploy scripts the region is already resolved and exported as
+// AWS_REGION, so this simply picks it up.
+const DEFAULT_REGION = 'us-east-1';
+
+function resolveRegion(explicit?: string): string {
+  if (explicit) return explicit;
+  if (process.env.AWS_REGION) return process.env.AWS_REGION;
+  if (process.env.AWS_DEFAULT_REGION) return process.env.AWS_DEFAULT_REGION;
+  try {
+    const cliRegion = execSync('aws configure get region', { encoding: 'utf-8' }).trim();
+    if (cliRegion) return cliRegion;
+  } catch {
+    // No configured region — fall through to the default.
+  }
+  return DEFAULT_REGION;
+}
 
 // ─── AWS CLI version requirements ───────────────────────────────────────────
 
@@ -420,53 +435,70 @@ async function main(): Promise<void> {
     jiraMcpAssociationId: '',
   };
 
-  // ─── Step 0: Select Region (always first) ───────────────────────────────
-  step(0, 'Select Target AWS Region');
+  // ─── Step 0: Resolve Target AWS Region (always first) ───────────────────
+  step(0, 'Resolve Target AWS Region');
 
-  info('DevOps Agent is available in these regions:');
-  const regionIdx = await askChoice('Which region do you want to deploy in?', SUPPORTED_REGIONS);
-  state.region = SUPPORTED_REGIONS[regionIdx];
+  // No hardcoded region shortlist: resolve from the environment / AWS CLI config
+  // (the shared deploy scripts export AWS_REGION after the shared prerequisites
+  // check). The shared prerequisites check proves AgentCore is reachable in this region.
+  state.region = resolveRegion(args.region);
   success(`Region: ${state.region}`);
-  recordStep('Select Region', 'succeeded');
+  info('(from --region, environment, or AWS CLI config; AgentCore availability is verified during prerequisites)');
+  recordStep('Resolve Region', 'succeeded');
 
   // ─── Step 1: Prerequisites ──────────────────────────────────────────────
   step(1, 'Checking prerequisites');
 
+  // When launched via the shared deploy scripts, the shared prerequisites
+  // script has already validated the AWS CLI (incl. version), credentials,
+  // region, and AgentCore availability, and exported the identity. Reuse that
+  // instead of re-running the same checks. Only the CDK availability check is
+  // wizard-specific (the shared script does not cover it). When the wizard is
+  // run standalone (no exported context), fall back to the full checks.
   let aborted = false;
+  const sharedPrereqsRan = Boolean(process.env.AWS_ACCOUNT_ID && process.env.AWS_ARN);
   const prerequisitesOk = await runStep('Check prerequisites', async () => {
-    try {
-      exec('aws --version', true);
-      success('AWS CLI installed');
-    } catch {
-      throw new Error('AWS CLI not found. Install it: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html');
-    }
-
-    const cliVersion = getAwsCliVersion();
-    if (!cliVersion) {
-      warn(`Could not parse AWS CLI version output. Continuing, but ${MIN_AWS_CLI_VERSION}+ is required for 'aws devops-agent'.`);
-    } else if (compareVersions(cliVersion, MIN_AWS_CLI_VERSION) < 0) {
-      throw new Error(
-        `AWS CLI ${cliVersion} is too old. The 'aws devops-agent' command requires ${MIN_AWS_CLI_VERSION} or newer. ` +
-        'Upgrade: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html'
-      );
+    if (sharedPrereqsRan) {
+      state.accountId = process.env.AWS_ACCOUNT_ID!;
+      success('Prerequisites already validated by shared check (AWS CLI, credentials, region, AgentCore)');
+      info(`Account: ${state.accountId} (${process.env.AWS_ARN})`);
     } else {
-      success(`AWS CLI ${cliVersion} (>= ${MIN_AWS_CLI_VERSION} required for devops-agent)`);
+      try {
+        exec('aws --version', true);
+        success('AWS CLI installed');
+      } catch {
+        throw new Error('AWS CLI not found. Install it: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html');
+      }
+
+      const cliVersion = getAwsCliVersion();
+      if (!cliVersion) {
+        warn(`Could not parse AWS CLI version output. Continuing, but ${MIN_AWS_CLI_VERSION}+ is required for 'aws devops-agent'.`);
+      } else if (compareVersions(cliVersion, MIN_AWS_CLI_VERSION) < 0) {
+        throw new Error(
+          `AWS CLI ${cliVersion} is too old. The 'aws devops-agent' command requires ${MIN_AWS_CLI_VERSION} or newer. ` +
+          'Upgrade: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html'
+        );
+      } else {
+        success(`AWS CLI ${cliVersion} (>= ${MIN_AWS_CLI_VERSION} required for devops-agent)`);
+      }
+
+      try {
+        const identity = execJson('aws sts get-caller-identity --no-cli-pager');
+        state.accountId = identity.Account;
+        success(`Authenticated as: ${identity.Arn}`);
+        info(`Account: ${state.accountId}`);
+      } catch {
+        throw new Error('AWS credentials not configured or session expired. Run: aws sso login');
+      }
     }
 
+    // CDK availability is not covered by the shared prerequisites script, so it
+    // is always checked here.
     try {
       exec('npx cdk --version', true);
       success('AWS CDK available');
     } catch {
       throw new Error('AWS CDK not found. Install it: npm install -g aws-cdk');
-    }
-
-    try {
-      const identity = execJson('aws sts get-caller-identity --no-cli-pager');
-      state.accountId = identity.Account;
-      success(`Authenticated as: ${identity.Arn}`);
-      info(`Account: ${state.accountId}`);
-    } catch {
-      throw new Error('AWS credentials not configured or session expired. Run: aws sso login');
     }
   });
 
@@ -733,24 +765,11 @@ async function runJiraOnly(args: CliOptions): Promise<void> {
   }
 
   // ─── Step 1: Region ─────────────────────────────────────────────────────
-  step(1, 'Select AWS Region');
+  step(1, 'Resolve AWS Region');
 
-  if (args.region) {
-    if (!SUPPORTED_REGIONS.includes(args.region)) {
-      console.error(`❌ Region '${args.region}' is not in the supported list: ${SUPPORTED_REGIONS.join(', ')}`);
-      rl.close();
-      return;
-    }
-    state.region = args.region;
-    success(`Region: ${state.region} (from --region)`);
-  } else {
-    const regionIdx = await askChoice(
-      'Which region is your existing deployment in?',
-      SUPPORTED_REGIONS
-    );
-    state.region = SUPPORTED_REGIONS[regionIdx];
-    success(`Region: ${state.region}`);
-  }
+  // No hardcoded shortlist — resolve from --region, environment, or AWS CLI config.
+  state.region = resolveRegion(args.region);
+  success(`Region: ${state.region}${args.region ? ' (from --region)' : ''}`);
 
   // ─── Step 2: Pick the existing Agent Space ──────────────────────────────
   step(2, 'Select existing DevOps Agent Space');
@@ -842,102 +861,114 @@ async function createAgentSpace(state: SetupState): Promise<void> {
 }
 
 async function ensureIamRoles(state: SetupState): Promise<void> {
-  // Check if AgentSpace role exists
+  // Trust policies are region-scoped via the aws:SourceArn condition
+  // (arn:aws:aidevops:<region>:...:agentspace/*). If a role was created in a
+  // previous run for a DIFFERENT region than the one now selected, reusing it
+  // as-is makes associate-service fail with "Invalid STS role configuration ...
+  // Verify the role's trust policy" — because the assuming agent space's ARN
+  // (in the current region) doesn't match the stale condition. So we always
+  // (re)apply the trust policy for the current region: create-role when the
+  // role is missing, update-assume-role-policy when it already exists. This is
+  // idempotent and self-heals a region change across runs.
+  const spaceTrust = {
+    Version: '2012-10-17',
+    Statement: [{
+      Effect: 'Allow',
+      Principal: { Service: 'aidevops.amazonaws.com' },
+      Action: 'sts:AssumeRole',
+      Condition: {
+        StringEquals: { 'aws:SourceAccount': state.accountId },
+        ArnLike: { 'aws:SourceArn': `arn:aws:aidevops:${state.region}:${state.accountId}:agentspace/*` },
+      },
+    }],
+  };
+  const webappTrust = {
+    Version: '2012-10-17',
+    Statement: [{
+      Effect: 'Allow',
+      Principal: { Service: 'aidevops.amazonaws.com' },
+      Action: ['sts:AssumeRole', 'sts:TagSession'],
+      Condition: {
+        StringEquals: { 'aws:SourceAccount': state.accountId },
+        ArnLike: { 'aws:SourceArn': `arn:aws:aidevops:${state.region}:${state.accountId}:agentspace/*` },
+      },
+    }],
+  };
+
   const spaceRoleExists = checkRoleExists('DevOpsAgentRole-AgentSpace');
   const webappRoleExists = checkRoleExists('DevOpsAgentRole-WebappAdmin');
 
-  if (spaceRoleExists && webappRoleExists) {
-    success('IAM roles already exist (DevOpsAgentRole-AgentSpace, DevOpsAgentRole-WebappAdmin)');
-    return;
-  }
-
-  info('Creating IAM roles for DevOps Agent...');
-
-  if (!spaceRoleExists) {
-    // Create AgentSpace role — use file:// to avoid shell quoting issues on Windows
-    const spaceTrustFile = writeTempJson('space-trust', {
-      Version: '2012-10-17',
-      Statement: [{
-        Effect: 'Allow',
-        Principal: { Service: 'aidevops.amazonaws.com' },
-        Action: 'sts:AssumeRole',
-        Condition: {
-          StringEquals: { 'aws:SourceAccount': state.accountId },
-          ArnLike: { 'aws:SourceArn': `arn:aws:aidevops:${state.region}:${state.accountId}:agentspace/*` },
-        },
-      }],
-    });
-
-    try {
+  // ─── AgentSpace role ──────────────────────────────────────────────────────
+  const spaceTrustFile = writeTempJson('space-trust', spaceTrust);
+  try {
+    if (spaceRoleExists) {
+      exec(
+        `aws iam update-assume-role-policy --role-name DevOpsAgentRole-AgentSpace --policy-document file://${spaceTrustFile} --no-cli-pager`,
+        true
+      );
+      success(`Updated trust policy: DevOpsAgentRole-AgentSpace (region ${state.region})`);
+    } else {
+      info('Creating IAM role: DevOpsAgentRole-AgentSpace...');
       exec(
         `aws iam create-role --role-name DevOpsAgentRole-AgentSpace --assume-role-policy-document file://${spaceTrustFile} --no-cli-pager`,
         true
       );
-    } finally {
-      tryUnlink(spaceTrustFile);
+      success('Created role: DevOpsAgentRole-AgentSpace');
     }
-
-    exec(
-      'aws iam attach-role-policy --role-name DevOpsAgentRole-AgentSpace --policy-arn arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy --no-cli-pager',
-      true
-    );
-
-    // Additional policy for Resource Explorer SLR
-    const additionalPolicyFile = writeTempJson('space-slr-policy', {
-      Version: '2012-10-17',
-      Statement: [{
-        Sid: 'AllowCreateServiceLinkedRoles',
-        Effect: 'Allow',
-        Action: ['iam:CreateServiceLinkedRole'],
-        Resource: [`arn:aws:iam::${state.accountId}:role/aws-service-role/resource-explorer-2.amazonaws.com/AWSServiceRoleForResourceExplorer`],
-      }],
-    });
-
-    try {
-      exec(
-        `aws iam put-role-policy --role-name DevOpsAgentRole-AgentSpace --policy-name AllowCreateServiceLinkedRoles --policy-document file://${additionalPolicyFile} --no-cli-pager`,
-        true
-      );
-    } finally {
-      tryUnlink(additionalPolicyFile);
-    }
-
-    success('Created role: DevOpsAgentRole-AgentSpace');
+  } finally {
+    tryUnlink(spaceTrustFile);
   }
 
-  if (!webappRoleExists) {
-    // Create WebappAdmin role — use file:// to avoid shell quoting issues on Windows
-    const webappTrustFile = writeTempJson('webapp-trust', {
-      Version: '2012-10-17',
-      Statement: [{
-        Effect: 'Allow',
-        Principal: { Service: 'aidevops.amazonaws.com' },
-        Action: ['sts:AssumeRole', 'sts:TagSession'],
-        Condition: {
-          StringEquals: { 'aws:SourceAccount': state.accountId },
-          ArnLike: { 'aws:SourceArn': `arn:aws:aidevops:${state.region}:${state.accountId}:agentspace/*` },
-        },
-      }],
-    });
+  // Attach managed + inline policies (idempotent — safe to re-run)
+  exec(
+    'aws iam attach-role-policy --role-name DevOpsAgentRole-AgentSpace --policy-arn arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy --no-cli-pager',
+    true
+  );
+  const additionalPolicyFile = writeTempJson('space-slr-policy', {
+    Version: '2012-10-17',
+    Statement: [{
+      Sid: 'AllowCreateServiceLinkedRoles',
+      Effect: 'Allow',
+      Action: ['iam:CreateServiceLinkedRole'],
+      Resource: [`arn:aws:iam::${state.accountId}:role/aws-service-role/resource-explorer-2.amazonaws.com/AWSServiceRoleForResourceExplorer`],
+    }],
+  });
+  try {
+    exec(
+      `aws iam put-role-policy --role-name DevOpsAgentRole-AgentSpace --policy-name AllowCreateServiceLinkedRoles --policy-document file://${additionalPolicyFile} --no-cli-pager`,
+      true
+    );
+  } finally {
+    tryUnlink(additionalPolicyFile);
+  }
 
-    try {
+  // ─── WebappAdmin role ─────────────────────────────────────────────────────
+  const webappTrustFile = writeTempJson('webapp-trust', webappTrust);
+  try {
+    if (webappRoleExists) {
+      exec(
+        `aws iam update-assume-role-policy --role-name DevOpsAgentRole-WebappAdmin --policy-document file://${webappTrustFile} --no-cli-pager`,
+        true
+      );
+      success(`Updated trust policy: DevOpsAgentRole-WebappAdmin (region ${state.region})`);
+    } else {
+      info('Creating IAM role: DevOpsAgentRole-WebappAdmin...');
       exec(
         `aws iam create-role --role-name DevOpsAgentRole-WebappAdmin --assume-role-policy-document file://${webappTrustFile} --no-cli-pager`,
         true
       );
-    } finally {
-      tryUnlink(webappTrustFile);
+      success('Created role: DevOpsAgentRole-WebappAdmin');
     }
-
-    exec(
-      'aws iam attach-role-policy --role-name DevOpsAgentRole-WebappAdmin --policy-arn arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy --no-cli-pager',
-      true
-    );
-
-    success('Created role: DevOpsAgentRole-WebappAdmin');
+  } finally {
+    tryUnlink(webappTrustFile);
   }
 
-  // Wait for IAM propagation
+  exec(
+    'aws iam attach-role-policy --role-name DevOpsAgentRole-WebappAdmin --policy-arn arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy --no-cli-pager',
+    true
+  );
+
+  // Wait for IAM propagation (create AND update both need time to reach STS)
   info('Waiting for IAM role propagation (10s)...');
   await new Promise((resolve) => setTimeout(resolve, 10000));
 }
@@ -979,9 +1010,32 @@ async function ensureAccountAssociation(state: SetupState): Promise<void> {
 
   let result: any;
   try {
-    result = execJson(
-      `aws devops-agent associate-service --agent-space-id ${state.agentSpaceId} --service-id aws --configuration file://${configFile} --region ${state.region} --no-cli-pager`
-    );
+    // associate-service assumes DevOpsAgentRole-AgentSpace. IAM role/trust-policy
+    // changes are eventually consistent, so a freshly created (or just-updated)
+    // role can still fail STS assume-role with "Invalid STS role configuration ...
+    // Verify the role's trust policy" for a short window after creation. Retry
+    // with backoff so the step succeeds once propagation completes instead of
+    // forcing the user to manually retry.
+    const maxAttempts = 6;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        result = execJson(
+          `aws devops-agent associate-service --agent-space-id ${state.agentSpaceId} --service-id aws --configuration file://${configFile} --region ${state.region} --no-cli-pager`
+        );
+        break;
+      } catch (err: any) {
+        const msg = String(err?.stderr || err?.message || err);
+        const isTransientTrust =
+          /Invalid STS role configuration/i.test(msg) ||
+          /Verify the role's trust policy/i.test(msg);
+        if (!isTransientTrust || attempt === maxAttempts) {
+          throw err;
+        }
+        const delaySec = attempt * 10; // 10s, 20s, 30s, ...
+        warn(`Association not ready yet (IAM propagation). Retrying in ${delaySec}s (attempt ${attempt}/${maxAttempts - 1})...`);
+        await new Promise((resolve) => setTimeout(resolve, delaySec * 1000));
+      }
+    }
   } finally {
     tryUnlink(configFile);
   }

--- a/observability/proactive-health-event-impact-analyzer/test/health-event-analyzer.test.ts
+++ b/observability/proactive-health-event-impact-analyzer/test/health-event-analyzer.test.ts
@@ -622,7 +622,7 @@ describe('HealthEventAnalyzerStack - SNS Topic Encryption and Resource Policy (R
     expect(denyInsecureStmt.Condition?.Bool?.['aws:SecureTransport']).toBe('false');
   });
 
-  test('SNS resource policy restricts subscribe/unsubscribe to owning account (Req 14.4)', () => {
+  test('SNS resource policy restricts subscribe to owning account (Req 14.4)', () => {
     const topicPolicies = template.findResources('AWS::SNS::TopicPolicy');
     const policyValues = Object.values(topicPolicies);
     const policy = policyValues[0] as any;
@@ -631,8 +631,11 @@ describe('HealthEventAnalyzerStack - SNS Topic Encryption and Resource Policy (R
     const subscribeStmt = statements.find((s: any) => s.Sid === 'RestrictSubscriptions');
     expect(subscribeStmt).toBeDefined();
     expect(subscribeStmt.Effect).toBe('Allow');
-    expect(subscribeStmt.Action).toContain('sns:Subscribe');
-    expect(subscribeStmt.Action).toContain('sns:Unsubscribe');
+    // Only sns:Subscribe is scoped. sns:Unsubscribe is NOT a valid action in an
+    // SNS resource policy — SNS rejects it at deploy time with "Policy statement
+    // action out of service scope", so it must not appear here.
+    expect(subscribeStmt.Action).toBe('sns:Subscribe');
+    expect(JSON.stringify(subscribeStmt.Action)).not.toContain('sns:Unsubscribe');
     // Principal should be the owning account
     expect(subscribeStmt.Principal?.AWS).toBeDefined();
   });

--- a/observability/proactive-health-event-impact-analyzer/test/lambda-logic.test.ts
+++ b/observability/proactive-health-event-impact-analyzer/test/lambda-logic.test.ts
@@ -5,32 +5,36 @@
 
 describe('Investigation Callback — Correlation', () => {
   // Simulate the extractCorrelationKey logic
+  function extractTag(text: string, prefix: string): string | null {
+    const start = text.indexOf(prefix);
+    if (start === -1) return null;
+    const valueStart = start + prefix.length;
+    const end = text.indexOf(']', valueStart);
+    if (end === -1) return null;
+    return text.substring(valueStart, end).trim() || null;
+  }
+
   function extractCorrelationKey(textContent: string): string | null {
-    // Primary: [CORRELATION_ID:{healthEventArn}] in description
-    const prefix = '[CORRELATION_ID:';
-    const startIdx = textContent.indexOf(prefix);
-    if (startIdx !== -1) {
-      const valueStart = startIdx + prefix.length;
-      const endIdx = textContent.indexOf(']', valueStart);
-      if (endIdx !== -1) {
-        const correlationId = textContent.substring(valueStart, endIdx).trim();
-        if (correlationId) return `arn:${correlationId}`;
-      }
-    }
+    // Primary: [INVESTIGATION_ID:{incidentId}] — unique per investigation
+    const investigationId = extractTag(textContent, '[INVESTIGATION_ID:');
+    if (investigationId) return investigationId;
+
+    // Legacy: [CORRELATION_ID:{healthEventArn}] — not unique across investigations
+    const correlationId = extractTag(textContent, '[CORRELATION_ID:');
+    if (correlationId) return `arn:${correlationId}`;
 
     // Fallback: [{incidentId}] in title
-    const titlePrefix = 'TITLE: [';
-    const titleIdx = textContent.indexOf(titlePrefix);
-    if (titleIdx !== -1) {
-      const idStart = titleIdx + titlePrefix.length;
-      const idEnd = textContent.indexOf(']', idStart);
-      if (idEnd !== -1) {
-        const incidentId = textContent.substring(idStart, idEnd).trim();
-        if (incidentId && incidentId.startsWith('health-')) return incidentId;
-      }
-    }
+    const titleIncidentId = extractTag(textContent, 'TITLE: [');
+    if (titleIncidentId && titleIncidentId.startsWith('health-')) return titleIncidentId;
 
     return null;
+  }
+
+  // Mirrors findTaskToken's branch selection: the `arn:` sentinel routes to the
+  // legacy healthEventId scan; everything else is the unique investigationId and
+  // uses the keyed GetItem. Locks the routing contract against regressions.
+  function lookupMode(correlationKey: string): 'keyed-getitem' | 'legacy-scan' {
+    return correlationKey.startsWith('arn:') ? 'legacy-scan' : 'keyed-getitem';
   }
 
   test('extracts healthEventArn from CORRELATION_ID tag', () => {
@@ -55,6 +59,35 @@ describe('Investigation Callback — Correlation', () => {
     const text = '[CORRELATION_ID:arn:aws:health:global::event/IAM/AWS_IAM_OPERATIONAL_NOTIFICATION/AWS_IAM_OPERATIONAL_NOTIFICATION_20260526] Description follows';
     const result = extractCorrelationKey(text);
     expect(result).toBe('arn:arn:aws:health:global::event/IAM/AWS_IAM_OPERATIONAL_NOTIFICATION/AWS_IAM_OPERATIONAL_NOTIFICATION_20260526');
+  });
+
+  test('extracts unique investigationId from INVESTIGATION_ID tag', () => {
+    const text = '[CORRELATION_ID:arn:aws:health:eu-west-1::event/EC2/AWS_EC2_SCHEDULED_MAINTENANCE/123]\n[INVESTIGATION_ID:health-EC2-1779753909631-a1b2c3d4]\nDescription follows';
+    const result = extractCorrelationKey(text);
+    expect(result).toBe('health-EC2-1779753909631-a1b2c3d4');
+  });
+
+  test('prefers INVESTIGATION_ID over the shared CORRELATION_ID (concurrent-safe)', () => {
+    // Two investigations for the SAME event share the CORRELATION_ID (event ARN)
+    // but have distinct INVESTIGATION_IDs. The unique id must win.
+    const arn = 'arn:aws:health:eu-west-1::event/EC2/AWS_EC2_SCHEDULED_MAINTENANCE/123';
+    const a = extractCorrelationKey(`[CORRELATION_ID:${arn}]\n[INVESTIGATION_ID:health-EC2-1-aaaa]\n...`);
+    const b = extractCorrelationKey(`[CORRELATION_ID:${arn}]\n[INVESTIGATION_ID:health-EC2-2-bbbb]\n...`);
+    expect(a).toBe('health-EC2-1-aaaa');
+    expect(b).toBe('health-EC2-2-bbbb');
+    expect(a).not.toBe(b);
+  });
+
+  test('unique investigationId routes to the keyed GetItem lookup', () => {
+    const key = extractCorrelationKey('[INVESTIGATION_ID:health-EC2-1779753909631-a1b2c3d4]\n...');
+    expect(key).toBe('health-EC2-1779753909631-a1b2c3d4');
+    expect(lookupMode(key!)).toBe('keyed-getitem');
+  });
+
+  test('legacy CORRELATION_ID key routes to the healthEventId scan (backward compat)', () => {
+    const key = extractCorrelationKey('[CORRELATION_ID:arn:aws:health:eu-west-1::event/EC2/X/1]\n...');
+    expect(key).toBe('arn:arn:aws:health:eu-west-1::event/EC2/X/1');
+    expect(lookupMode(key!)).toBe('legacy-scan');
   });
 });
 
@@ -141,6 +174,80 @@ describe('OpsCenter Creator — Severity Mapping', () => {
   });
 });
 
+describe('Investigation Callback — Severity From Findings', () => {
+  const SEVERITY_RANK: Record<string, number> = { CRITICAL: 4, HIGH: 3, MEDIUM: 2, LOW: 1, MINIMAL: 0 };
+
+  function parseSeverity(text: string): string | null {
+    const m = text.trim().toUpperCase().match(/^[*_\s]*(CRITICAL|HIGH|MEDIUM|LOW|MINIMAL)\b/);
+    return m ? m[1] : null;
+  }
+
+  function highestSeverity(severities: string[]): string | null {
+    let best: string | null = null;
+    for (const s of severities) {
+      if (best === null || (SEVERITY_RANK[s] ?? -1) > (SEVERITY_RANK[best] ?? -1)) best = s;
+    }
+    return best;
+  }
+
+  // Mirrors buildOutput's priority derivation.
+  function derivePriority(hasImpact: boolean, overallSeverity: string | null, taskPriority: string): string {
+    return hasImpact ? (overallSeverity || taskPriority) : 'LOW';
+  }
+
+  // Mirrors parseAgentAnalysis: findings are capped at 5 for display, but the
+  // overall severity is computed across ALL findings.
+  function overallFromBullets(severities: string[]): { displayed: number; overall: string | null } {
+    return { displayed: Math.min(severities.length, 5), overall: highestSeverity(severities) };
+  }
+
+  test('parses the severity word from a Key Findings bullet', () => {
+    expect(parseSeverity('HIGH — service will be unavailable, no redundancy')).toBe('HIGH');
+    expect(parseSeverity('low impact, full redundancy in place')).toBe('LOW');
+  });
+
+  test('returns null when no severity word is present', () => {
+    expect(parseSeverity('the web tier reads from the affected database')).toBeNull();
+  });
+
+  test('only accepts a severity word that leads the bullet detail', () => {
+    // Leading severity (skill format) → parsed.
+    expect(parseSeverity('CRITICAL — will be unavailable, no redundancy')).toBe('CRITICAL');
+    expect(parseSeverity('**HIGH** — significant degradation')).toBe('HIGH');
+    // Severity word only later in the sentence → not misread.
+    expect(parseSeverity('baseline is fine, escalates to CRITICAL under load')).toBeNull();
+  });
+
+  test('overall severity considers findings beyond the 5-finding display cap', () => {
+    // 6 workloads; the CRITICAL one is 6th and dropped from the displayed findings,
+    // but must still drive the overall severity (else the OpsItem is under-reported).
+    const severities = ['LOW', 'LOW', 'MEDIUM', 'LOW', 'MEDIUM', 'CRITICAL'];
+    const { displayed, overall } = overallFromBullets(severities);
+    expect(displayed).toBe(5);
+    expect(overall).toBe('CRITICAL');
+  });
+
+  test('overall severity is the highest across findings', () => {
+    expect(highestSeverity(['LOW', 'HIGH', 'MEDIUM'])).toBe('HIGH');
+    expect(highestSeverity(['CRITICAL', 'HIGH'])).toBe('CRITICAL');
+    expect(highestSeverity([])).toBeNull();
+  });
+
+  test('no-impact result is LOW despite a HIGH intake priority', () => {
+    // scheduledChange maps to HIGH at intake, but the agent found no impact.
+    expect(derivePriority(false, null, 'HIGH')).toBe('LOW');
+  });
+
+  test('impact severity comes from findings, not the intake priority', () => {
+    // Agent concluded LOW even though the event category mapped to HIGH at intake.
+    expect(derivePriority(true, 'LOW', 'HIGH')).toBe('LOW');
+  });
+
+  test('falls back to task priority when impact exists but no severity was parsed', () => {
+    expect(derivePriority(true, null, 'HIGH')).toBe('HIGH');
+  });
+});
+
 describe('Investigation Trigger — Webhook Title', () => {
   function buildTitle(incidentId: string, service: string, eventType: string, region: string): string {
     return `[${incidentId}] AWS Health: ${service} ${eventType} in ${region}`;
@@ -162,22 +269,30 @@ describe('Investigation Trigger — Webhook Title', () => {
 });
 
 describe('Investigation Trigger — Description Correlation Tag', () => {
-  function buildDescription(eventId: string): string {
-    return `[CORRELATION_ID:${eventId}]\n\nAWS Health Event detected...`;
+  function buildDescription(eventId: string, incidentId: string): string {
+    return `[CORRELATION_ID:${eventId}]\n[INVESTIGATION_ID:${incidentId}]\n\nAWS Health Event detected...`;
   }
 
   test('CORRELATION_ID is the first thing in the description', () => {
-    const desc = buildDescription('arn:aws:health:eu-west-1::event/EC2/TEST/123');
+    const desc = buildDescription('arn:aws:health:eu-west-1::event/EC2/TEST/123', 'health-EC2-1-aaaa');
     expect(desc.startsWith('[CORRELATION_ID:')).toBe(true);
   });
 
   test('CORRELATION_ID value is extractable', () => {
-    const desc = buildDescription('arn:aws:health:global::event/IAM/NOTIF/456');
+    const desc = buildDescription('arn:aws:health:global::event/IAM/NOTIF/456', 'health-IAM-1-bbbb');
     const prefix = '[CORRELATION_ID:';
     const start = desc.indexOf(prefix) + prefix.length;
     const end = desc.indexOf(']', start);
     const value = desc.substring(start, end);
     expect(value).toBe('arn:aws:health:global::event/IAM/NOTIF/456');
+  });
+
+  test('INVESTIGATION_ID value is present and extractable', () => {
+    const desc = buildDescription('arn:aws:health:global::event/IAM/NOTIF/456', 'health-IAM-1779753909631-bbbb');
+    const prefix = '[INVESTIGATION_ID:';
+    const start = desc.indexOf(prefix) + prefix.length;
+    const end = desc.indexOf(']', start);
+    expect(desc.substring(start, end)).toBe('health-IAM-1779753909631-bbbb');
   });
 });
 

--- a/observability/proactive-health-event-impact-analyzer/test/setup-wizard.test.ts
+++ b/observability/proactive-health-event-impact-analyzer/test/setup-wizard.test.ts
@@ -22,26 +22,37 @@ describe('setup-wizard production readiness', () => {
     wizardSource = fs.readFileSync(WIZARD_PATH, 'utf-8');
   });
 
-  describe('Requirement 16.2: Region prompt before deployment', () => {
-    it('prompts for region as the first step (Step 0) in the main flow', () => {
-      // The region selection should be Step 0, before any prerequisites or deployment
+  describe('Requirement 16.2: Region resolved before deployment', () => {
+    it('resolves the region as the first step (Step 0) in the main flow', () => {
+      // Region is established as Step 0, before any prerequisites or deployment.
+      // Per review feedback the wizard no longer prompts from a hardcoded region
+      // shortlist; it resolves the region from the environment / AWS CLI config
+      // and lets the shared prerequisites check verify AgentCore availability.
       const regionStepMatch = wizardSource.match(
-        /step\(0,\s*['"`]Select Target AWS Region['"`]\)/
+        /step\(0,\s*['"`]Resolve Target AWS Region['"`]\)/
       );
       expect(regionStepMatch).not.toBeNull();
     });
 
-    it('region selection occurs before CDK deployment step in source order', () => {
-      const regionPromptIdx = wizardSource.indexOf("'Select Target AWS Region'");
+    it('does not hardcode a region shortlist', () => {
+      // The old SUPPORTED_REGIONS picker rotted and was inaccurate; it must not
+      // return. Availability is proven at runtime by the shared prerequisites
+      // check (check-prerequisites --required-service agentcore).
+      expect(wizardSource).not.toContain('SUPPORTED_REGIONS');
+      expect(wizardSource).toContain('function resolveRegion');
+    });
+
+    it('region resolution occurs before CDK deployment step in source order', () => {
+      const regionPromptIdx = wizardSource.indexOf("'Resolve Target AWS Region'");
       const cdkDeployIdx = wizardSource.indexOf("'CDK Deployment'");
       expect(regionPromptIdx).toBeGreaterThan(-1);
       expect(cdkDeployIdx).toBeGreaterThan(-1);
       expect(regionPromptIdx).toBeLessThan(cdkDeployIdx);
     });
 
-    it('region selection occurs before any DevOps Agent API calls', () => {
-      // In the main flow, region is selected first (Step 0), prerequisites are Step 1
-      const regionStepIdx = wizardSource.indexOf("step(0, 'Select Target AWS Region')");
+    it('region resolution occurs before any DevOps Agent API calls', () => {
+      // In the main flow, region is resolved first (Step 0), prerequisites are Step 1
+      const regionStepIdx = wizardSource.indexOf("step(0, 'Resolve Target AWS Region')");
       const prerequisitesIdx = wizardSource.indexOf("step(1, 'Checking prerequisites')");
       expect(regionStepIdx).toBeGreaterThan(-1);
       expect(prerequisitesIdx).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

Re-lands the production hardening from #106 (which I reverted in #110 because I merged it before the review was addressed), this time resolving all three of @benlec's review points. Built on top of current `main`.

## Addressing @benlec's review

**1. Removed the hardcoded region shortlist.**
The setup wizard no longer prompts from a static `SUPPORTED_REGIONS` list (it was inaccurate — missing eu-west-3 — and rots as availability changes). It now resolves the region the same way the shared scripts do — `AWS_DEFAULT_REGION` → `AWS_REGION` → `aws configure get region` → `us-east-1` — via a `resolveRegion()` helper, and relies on the shared `check-prerequisites --required-service agentcore`, which calls `bedrock-agentcore-control list-agent-runtimes` to prove AgentCore is actually reachable in that region. No list to maintain.

**2. Fixed the Windows bundling failure at the root (not a retry).**
`spawnSync powershell.exe ENOENT` is the pre-patch `NodejsFunction` behaviour: `aws-cdk-lib < 2.246.0` assembled the esbuild invocation as a command string and executed it through a host shell (`cmd`/`powershell` on Windows). Bumped `aws-cdk-lib` `^2.150.0` → `^2.246.0` (and the `aws-cdk` CLI to `^2.1006.0`), which runs esbuild via array-based `spawnSync` with **no shell** — deterministic and cross-platform. Documented inline at the bundling options. (Ref: advisory GHSA-999r-qq7v-r334, which also closes the OS-command-injection issue.)

**3. Removed the duplicate prerequisites check.**
`deploy-all.sh` / `deploy-all.ps1` now call the shared `check-prerequisites` once — with the correct `--required-service agentcore` instead of `bedrock` — and export `AWS_REGION` / `AWS_ACCOUNT_ID` / `AWS_ARN`. The wizard reuses those instead of re-running the same CLI/credential/region checks. Only the wizard-specific CDK availability check remains; the full checks still run when the wizard is invoked standalone.

## Re-applied hardening (uncontested in #106)

- **DynamoDB**: deletion protection + `RETAIN` in production, disposable (`DESTROY`) in non-production, for the task-token, teams, and agent-spaces tables.
- **SNS topic policy**: `DenyInsecureTransport` + `RestrictSubscriptions`, using only actions valid in an SNS resource policy.
- **Correlation**: prefer a unique `INVESTIGATION_ID` over the shared `CORRELATION_ID`; keyed `GetItem` instead of a scan; delete the exact resolved row. Random suffix on the incident id for concurrency safety. Dropped the duplicate `scheduledChange` EventBridge rule.
- **Setup wizard**: self-heal the DevOps Agent role trust policy for the current region on every run; retry account association with backoff for IAM propagation. Run via the locally pinned `ts-node`.

## Testing

Verified on **macOS**:
- `tsc` build: clean
- `jest`: **250/250** across 6 suites
- `cdk synth`: succeeds, all four `NodejsFunction` constructs bundle via esbuild; synth template confirms the SNS + DynamoDB hardening

## ⚠️ Needs a Windows check before merge

I don't have a Windows host, so I could **not** validate point 2 (cross-platform bundling) on Windows — only on macOS. Per @benlec's request, could someone run `cdk synth` / a deploy on Windows before this merges? The fix is a framework-version bump that removes the shell shell-out, so it should be correct, but it should be confirmed on the platform where it originally failed.

Supersedes #106; reverts the revert in #110.
