### PR TITLE
[proactive-health-event-impact-analyzer] Verify DevOps Agent region availability with the correct service

### DIFF
--- a/observability/proactive-health-event-impact-analyzer/README.md
+++ b/observability/proactive-health-event-impact-analyzer/README.md
@@ -48,6 +48,12 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for detailed component descriptions and
 
 ## Prerequisites
 
+- Deploy in a Region where AWS DevOps Agent is generally available. The setup
+  probes the DevOps Agent API in your resolved Region, but the API can respond
+  in Regions where the service is not yet fully launched (no console support).
+  **As of today, deploy only to a Region listed in the official
+  [AWS DevOps Agent supported Regions](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-supported-regions.html)**
+  to get full functionality including the DevOps Agent console.
 - AWS account with permissions to create IAM roles, Lambda, Step Functions, DynamoDB, SNS, and SSM resources
 - AWS CLI v2.34.20+ installed and authenticated (`aws sts get-caller-identity` should work)
 - Node.js 24+ and npm installed (Lambda functions run on Node.js 24)

--- a/observability/proactive-health-event-impact-analyzer/deploy-all.ps1
+++ b/observability/proactive-health-event-impact-analyzer/deploy-all.ps1
@@ -105,13 +105,13 @@ Write-Host "========================================" -ForegroundColor Cyan
 if (-not $SkipSetup) {
     # Use shared prerequisites if available (monorepo), otherwise inline checks.
     # The shared script validates the AWS CLI, credentials, region, and — via
-    # -RequiredService agentcore — that AWS DevOps Agent (AgentCore) is actually
-    # reachable in the resolved region, then sets $global:AWS_REGION / AWS_ACCOUNT_ID
-    # / AWS_ARN. The wizard reuses those instead of re-checking, so prerequisites
-    # are validated exactly once.
+    # -RequiredService devops-agent — that AWS DevOps Agent (service principal
+    # aidevops) is actually reachable in the resolved region, then sets
+    # $global:AWS_REGION / AWS_ACCOUNT_ID / AWS_ARN. The wizard reuses those
+    # instead of re-checking, so prerequisites are validated exactly once.
     $sharedPrereqs = Join-Path $ScriptDir "..\..\shared\scripts\check-prerequisites.ps1"
     if (Test-Path $sharedPrereqs) {
-        & $sharedPrereqs -RequiredService "agentcore" -MinAwsCliVersion "2.34.20"
+        & $sharedPrereqs -RequiredService "devops-agent" -MinAwsCliVersion "2.34.20"
         $region = $global:AWS_REGION
         # Hand the validated context to the wizard so it does not re-run these checks.
         $env:AWS_REGION = $global:AWS_REGION

--- a/observability/proactive-health-event-impact-analyzer/deploy-all.sh
+++ b/observability/proactive-health-event-impact-analyzer/deploy-all.sh
@@ -119,13 +119,14 @@ echo "========================================"
 if [ "$SKIP_SETUP" = false ]; then
     # Use shared prerequisites if available (monorepo), otherwise inline checks.
     # The shared script validates the AWS CLI, credentials, region, and — via
-    # --required-service agentcore — that AWS DevOps Agent (AgentCore) is actually
-    # reachable in the resolved region (it calls bedrock-agentcore-control), then
-    # exports AWS_REGION / AWS_ACCOUNT_ID / AWS_ARN. The wizard reuses those exports
-    # instead of re-checking, so prerequisites are validated exactly once.
+    # --required-service devops-agent — that AWS DevOps Agent (service principal
+    # aidevops) is actually reachable in the resolved region (it calls
+    # `aws devops-agent list-agent-spaces`), then exports AWS_REGION /
+    # AWS_ACCOUNT_ID / AWS_ARN. The wizard reuses those exports instead of
+    # re-checking, so prerequisites are validated exactly once.
     SHARED_PREREQS="$SCRIPT_DIR/../../shared/scripts/check-prerequisites.sh"
     if [ -f "$SHARED_PREREQS" ]; then
-        source "$SHARED_PREREQS" --required-service agentcore --min-aws-cli-version 2.34.20
+        source "$SHARED_PREREQS" --required-service devops-agent --min-aws-cli-version 2.34.20
         region=$AWS_REGION
         # Hand the validated context to the wizard so it does not re-run these checks.
         export AWS_REGION AWS_ACCOUNT_ID AWS_ARN

--- a/observability/proactive-health-event-impact-analyzer/scripts/setup-wizard.ts
+++ b/observability/proactive-health-event-impact-analyzer/scripts/setup-wizard.ts
@@ -290,21 +290,23 @@ const SSM_PARAM_JIRA_SITE_URL = '/health-analyzer/jira/siteUrl';
 
 // ─── Region Resolution ──────────────────────────────────────────────────────
 
-// The wizard does NOT hardcode a region shortlist. AWS DevOps Agent (AgentCore)
+// The wizard does NOT hardcode a region shortlist. AWS DevOps Agent region
 // availability shifts over time, so a static list rots and is inaccurate. Instead
 // we resolve the region exactly like the shared deploy scripts and the shared
 // prerequisites check do — environment first, then the AWS CLI's configured
 // region, then a safe default — and let the shared prerequisites check
-// (`check-prerequisites --required-service agentcore`) prove the service is
-// actually reachable in that region by calling it. When invoked through the
+// (`check-prerequisites --required-service devops-agent`) prove AWS DevOps Agent
+// is actually reachable in that region by calling it. When invoked through the
 // shared deploy scripts the region is already resolved and exported as
 // AWS_REGION, so this simply picks it up.
 const DEFAULT_REGION = 'us-east-1';
 
 function resolveRegion(explicit?: string): string {
   if (explicit) return explicit;
-  if (process.env.AWS_REGION) return process.env.AWS_REGION;
+  // Precedence matches the shared scripts / repo convention: AWS_DEFAULT_REGION
+  // takes priority over AWS_REGION, then the AWS CLI's configured region.
   if (process.env.AWS_DEFAULT_REGION) return process.env.AWS_DEFAULT_REGION;
+  if (process.env.AWS_REGION) return process.env.AWS_REGION;
   try {
     const cliRegion = execSync('aws configure get region', { encoding: 'utf-8' }).trim();
     if (cliRegion) return cliRegion;
@@ -440,10 +442,10 @@ async function main(): Promise<void> {
 
   // No hardcoded region shortlist: resolve from the environment / AWS CLI config
   // (the shared deploy scripts export AWS_REGION after the shared prerequisites
-  // check). The shared prerequisites check proves AgentCore is reachable in this region.
+  // check). The shared prerequisites check proves AWS DevOps Agent is reachable in this region.
   state.region = resolveRegion(args.region);
   success(`Region: ${state.region}`);
-  info('(from --region, environment, or AWS CLI config; AgentCore availability is verified during prerequisites)');
+  info('(from --region, environment, or AWS CLI config; DevOps Agent availability is verified during prerequisites)');
   recordStep('Resolve Region', 'succeeded');
 
   // ─── Step 1: Prerequisites ──────────────────────────────────────────────
@@ -451,7 +453,7 @@ async function main(): Promise<void> {
 
   // When launched via the shared deploy scripts, the shared prerequisites
   // script has already validated the AWS CLI (incl. version), credentials,
-  // region, and AgentCore availability, and exported the identity. Reuse that
+  // region, and DevOps Agent availability, and exported the identity. Reuse that
   // instead of re-running the same checks. Only the CDK availability check is
   // wizard-specific (the shared script does not cover it). When the wizard is
   // run standalone (no exported context), fall back to the full checks.
@@ -460,7 +462,7 @@ async function main(): Promise<void> {
   const prerequisitesOk = await runStep('Check prerequisites', async () => {
     if (sharedPrereqsRan) {
       state.accountId = process.env.AWS_ACCOUNT_ID!;
-      success('Prerequisites already validated by shared check (AWS CLI, credentials, region, AgentCore)');
+      success('Prerequisites already validated by shared check (AWS CLI, credentials, region, DevOps Agent)');
       info(`Account: ${state.accountId} (${process.env.AWS_ARN})`);
     } else {
       try {

--- a/shared/scripts/check-prerequisites.ps1
+++ b/shared/scripts/check-prerequisites.ps1
@@ -166,6 +166,21 @@ if (-not $SkipServiceCheck -and -not [string]::IsNullOrEmpty($RequiredService)) 
             }
             Write-Host "      OK: AgentCore Browser Tool is available in $currentRegion" -ForegroundColor Green
         }
+        "devops-agent" {
+            # Probe the actual AWS DevOps Agent service (aidevops) in this region.
+            # A region with no reachable aidevops endpoint fails at endpoint
+            # resolution and we stop here. Probing the live service avoids a
+            # hardcoded region list, which rots and would reject regions where the
+            # service is already reachable ahead of the docs. (Different service
+            # from Bedrock AgentCore, which the "agentcore" case probes.)
+            $null = aws devops-agent list-agent-spaces --region $currentRegion --no-cli-pager 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "      ERROR: AWS DevOps Agent is not available in region: $currentRegion" -ForegroundColor Red
+                Write-Host "      https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-supported-regions.html" -ForegroundColor Gray
+                exit 1
+            }
+            Write-Host "      OK: AWS DevOps Agent is available in $currentRegion" -ForegroundColor Green
+        }
         "nova-act" {
             $null = aws nova-act list-workflow-definitions --region $currentRegion 2>&1
             if ($LASTEXITCODE -ne 0) {

--- a/shared/scripts/check-prerequisites.sh
+++ b/shared/scripts/check-prerequisites.sh
@@ -222,6 +222,22 @@ if [ "$SKIP_SERVICE_CHECK" = false ] && [ -n "$REQUIRED_SERVICE" ]; then
             fi
             echo -e "\033[0;32m      ✓ AgentCore Browser Tool is available in $CURRENT_REGION\033[0m"
             ;;
+        "devops-agent")
+            # Probe the actual AWS DevOps Agent service (aidevops) in this region.
+            # A region with no reachable aidevops endpoint fails at endpoint
+            # resolution and we stop here. Probing the live service avoids a
+            # hardcoded region list, which rots and would reject regions where the
+            # service is already reachable ahead of the docs. (This is a different
+            # service from Bedrock AgentCore, which the "agentcore" case probes.)
+            if ! aws devops-agent list-agent-spaces --region "$CURRENT_REGION" --no-cli-pager > /dev/null 2>&1; then
+                echo -e "\033[0;31m      ❌ AWS DevOps Agent is not available in region: $CURRENT_REGION\033[0m"
+                echo -e ""
+                echo -e "\033[0;90m      For supported regions, see:\033[0m"
+                echo -e "\033[0;90m      https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-supported-regions.html\033[0m"
+                exit 1
+            fi
+            echo -e "\033[0;32m      ✓ AWS DevOps Agent is available in $CURRENT_REGION\033[0m"
+            ;;
         "nova-act")
             if ! aws nova-act list-workflow-definitions --region "$CURRENT_REGION" > /dev/null 2>&1; then
                 echo -e "\033[0;31m      ❌ Amazon Nova Act is not available in region: $CURRENT_REGION\033[0m"


### PR DESCRIPTION
## Summary

Follow-up to the re-landed hardening (PR #106 review). Two correctness fixes
around region handling, on top of current `main`. Builds on the "no hardcoded
region shortlist" decision from that review — and reinforces it with evidence.

## 1. Probe the correct service for region availability

The deploy scripts validated region availability via
`check-prerequisites --required-service agentcore`, which probes **Amazon
Bedrock AgentCore** (`bedrock-agentcore-control`). This demo uses **AWS DevOps
Agent** (`aidevops`) — a different service — so the check didn't actually
exercise DevOps Agent.

This PR adds a `devops-agent` case to the shared `check-prerequisites` scripts
that probes the real service (`aws devops-agent list-agent-spaces`) in the
resolved region:
- Where the DevOps Agent endpoint isn't reachable, the call fails at endpoint
  resolution and we stop with a clear message.
- Where the service responds, we proceed.

`deploy-all.ps1` / `deploy-all.sh` now pass `--required-service devops-agent`.

**Why a live probe rather than a hardcoded region list:** availability changes
over time and the docs lag the service. In testing, a full end-to-end deployment
succeeded in `us-east-2`, which is **not** in the currently documented
supported-region list — DevOps Agent setup (Agent Space creation, account
association returning `valid`, webhook, operator app) *and* the CDK stack all
completed there. A static allowlist would have wrongly rejected a region where
the solution actually works. Probing the service reflects reality; a hardcoded
list rots.

The shared-script change is purely additive (a new `case` only) and does not
affect other demos.

## 2. `resolveRegion` precedence

Aligned the environment precedence to `AWS_DEFAULT_REGION → AWS_REGION`, matching
the shared scripts and the repo's documented region-detection convention (it was
checking `AWS_REGION` first). Also corrected stale "AgentCore" wording to
"DevOps Agent" in the wizard comments/output.

## Maintenance

The runtime probe plus the README pointer to the official supported-regions page
means there is **no hardcoded region list to maintain**. As AWS DevOps Agent
becomes available in new Regions, the probe picks them up automatically — no code
change needed — and the README already directs users to the authoritative,
always-current list of supported Regions. The approach adapts on its own instead
of rotting the way a static shortlist would.

## Testing

- `tsc` build passes.
- `setup-wizard` unit tests pass (33/33), including the
  "does not hardcode a region shortlist" assertion — this PR keeps that behavior.
- Both shell scripts pass `bash -n`.
- Real-AWS validation: the new `devops-agent` prerequisite check passes, and a
  full end-to-end deployment completes in `us-east-2` — DevOps Agent setup
  (Agent Space, account association `valid`, webhook, operator app) and the CDK
  stack deployment all succeed.
- Negative path: the probe correctly fails for regions with no reachable DevOps
  Agent endpoint (e.g. `us-west-1`) and for invalid region strings.

---
*Draft: opened for early review. Follow-up to the region/prereq review on #106.*
