### PR TITLE
observability: Migrate DevOps Agent setup to CDK L1 constructs

### DIFF
--- a/observability/proactive-health-event-impact-analyzer/ARCHITECTURE.md
+++ b/observability/proactive-health-event-impact-analyzer/ARCHITECTURE.md
@@ -125,11 +125,51 @@ The Step Functions workflow uses the **Wait for Task Token** pattern to integrat
 6. Investigation Callback Lambda retrieves the token from DynamoDB
 7. Calls `SendTaskSuccess` or `SendTaskFailure` to resume the workflow
 
+## AWS DevOps Agent Provisioning
+
+The Agent Space, its IAM roles, the AWS account monitor association, the
+operator app, and the generic `eventChannel` webhook are provisioned by a
+dedicated CDK stack — `DevOpsAgentSpaceStack`
+(`infrastructure/cdk/lib/devops-agent-space-stack.ts`, backed by the
+`DevOpsAgentSpace` construct in `lib/constructs/devops-agent-space.ts`) — using
+AWS CloudFormation's `AWS::DevOpsAgent::AgentSpace`, `AWS::DevOpsAgent::Association`,
+and IAM L1/L2 constructs. This replaced an earlier design where the setup
+wizard drove these steps with the `aws devops-agent` CLI directly.
+
+This stack deploys independently of the main `HealthEventAnalyzerStack` and
+can target a different Region (`DEVOPS_AGENT_REGION`; see the README) since an
+Agent Space monitors resources across *all* Regions of an associated account.
+`scripts/setup-wizard.ts` deploys it first, reads its `AgentSpaceId`,
+`WebhookUrl`, and `WebhookSecretArn` outputs via `aws cloudformation
+describe-stacks`, and threads them into the main stack's synthesis as CDK
+context (`-c devOpsAgentWebhookUrl=... -c devOpsAgentWebhookSecretArn=...`) —
+there is no CloudFormation parameter for either value.
+
+**Why the webhook still needs a Lambda-backed custom resource**: AWS DevOps
+Agent returns the webhook's HMAC secret exactly once, in the `AssociateService`
+API response — no `Describe`/`List` call ever returns it again, and
+`AWS::DevOpsAgent::Association` exposes no webhook attributes for
+CloudFormation to surface. (`AWS::DevOpsAgent::Service` also has no
+`eventChannel` service-details type, so registering that service can't be
+expressed as a CloudFormation resource either.) The custom resource
+(`lambda/devops-agent-webhook-provisioner/index.ts`) performs
+`RegisterService(eventChannel)` + `AssociateService` at deploy time and writes
+the secret directly into a Secrets Manager secret — the value never enters
+CloudFormation state, template outputs, or this repository's scripts. Any
+property change on the custom resource rotates the webhook (replacement =
+delete + recreate), since the secret can't be re-read to preserve it across an
+update.
+
 ## Security
 
-- HMAC-SHA256 webhook authentication (secret stored in SSM SecureString, never transmitted in plaintext)
+- HMAC-SHA256 webhook authentication (secret stored in a CDK-managed Secrets
+  Manager secret, written once by the webhook provisioning custom resource
+  and never transmitted in plaintext through this repository's scripts)
 - Least-privilege IAM roles per Lambda function (scoped to specific resource ARNs)
-- Secrets stored in SSM Parameter Store SecureString (not CloudFormation parameters)
+- Slack/MS Teams webhook secrets stored in SSM Parameter Store SecureString
+  (set by the setup wizard); the DevOps Agent webhook secret is Secrets
+  Manager instead (see "AWS DevOps Agent Provisioning" above). Neither is a
+  CloudFormation parameter.
 - DynamoDB TTL on task tokens (1 hour expiry)
 - CloudWatch log retention: 90 days (production), 14 days (staging)
 - PAY_PER_REQUEST billing (no over-provisioning)

--- a/observability/proactive-health-event-impact-analyzer/README.md
+++ b/observability/proactive-health-event-impact-analyzer/README.md
@@ -15,7 +15,7 @@ When AWS Health publishes an event — scheduled maintenance, operational issues
 | **Duration** | 20 minutes (deployment) |
 | **Difficulty** | Intermediate |
 | **Target Audience** | SREs, Platform Engineers, DevOps Engineers |
-| **Key Technologies** | AWS DevOps Agent, Step Functions, EventBridge, Lambda, DynamoDB, SNS, Systems Manager OpsCenter |
+| **Key Technologies** | AWS DevOps Agent, Step Functions, EventBridge, Lambda, DynamoDB, SNS, Secrets Manager, Systems Manager OpsCenter |
 | **Estimated Cost** | ~$5-15/month (varies with event volume) |
 
 ## Architecture
@@ -54,7 +54,7 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) for detailed component descriptions and
   **As of today, deploy only to a Region listed in the official
   [AWS DevOps Agent supported Regions](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-supported-regions.html)**
   to get full functionality including the DevOps Agent console.
-- AWS account with permissions to create IAM roles, Lambda, Step Functions, DynamoDB, SNS, and SSM resources
+- AWS account with permissions to create IAM roles, Lambda, Step Functions, DynamoDB, SNS, SSM, Secrets Manager, and AWS DevOps Agent (`AWS::DevOpsAgent::*`) resources
 - AWS CLI v2.34.20+ installed and authenticated (`aws sts get-caller-identity` should work)
 - Node.js 24+ and npm installed (Lambda functions run on Node.js 24)
 - An active [CloudTrail trail](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-create-a-trail-using-the-console-first-time.html) capturing management events in the deployment region
@@ -110,6 +110,26 @@ Steps 3–5 handle notification and Jira secrets: Slack/MS Teams webhook URLs go
 to SSM Parameter Store SecureString; the DevOps Agent webhook secret is
 written directly to Secrets Manager by CDK and never passes through this
 script.
+
+### Upgrading from an Older, CLI-Based Deployment
+
+Earlier versions of this sample created the Agent Space, its IAM roles, the
+account association, and the webhook with direct `aws devops-agent` CLI calls
+from the wizard. If you deployed with one of those versions, re-running the
+current wizard **creates a brand-new Agent Space** (CDK-managed) rather than
+adopting your existing one — `AWS::DevOpsAgent::AgentSpace` has no import
+mechanism, and the DevOps Agent API allows duplicate names, so the deploy
+won't fail, it'll just leave you with two Agent Spaces both named
+`health-event-analyzer`.
+
+After confirming the new stack works (test with a sample event — see
+[Testing](#testing) below), clean up the old, now-unused resources:
+- The old Agent Space (`aws devops-agent list-agent-spaces --region <region>`
+  to find its ID, then disassociate its services and delete it)
+- The old fixed-name IAM roles `DevOpsAgentRole-AgentSpace` and
+  `DevOpsAgentRole-WebappAdmin` (the new roles are project-prefixed —
+  `health-event-analyzer-AgentSpaceRole` / `-OperatorRole` — so there's no
+  naming conflict, but the old ones are now orphaned)
 
 ### Cleanup
 
@@ -248,11 +268,12 @@ See [docs/multi-account-setup.md](./docs/multi-account-setup.md) for the full mu
 
 | Service | Monthly Cost | Notes |
 |---------|-------------|-------|
-| Lambda | ~$1-3 | 5 functions, invoked per Health event |
+| Lambda | ~$1-3 | 5 functions invoked per Health event, plus a 6th (webhook provisioner) that only runs once per deploy/destroy — negligible cost |
 | Step Functions | ~$1 | Standard workflow, ~100 executions/month |
 | DynamoDB | ~$1 | On-demand, three tables with minimal storage |
 | EventBridge | ~$0.50 | Rule evaluations |
 | SNS | ~$0.50 | Email notifications |
+| Secrets Manager | ~$0.40 | One secret for the DevOps Agent webhook HMAC key |
 | Systems Manager OpsCenter | ~$0 | Free tier covers typical usage |
 | DevOps Agent | Included | Part of AWS DevOps Agent pricing |
 | **Total** | **~$5-15/month** | Varies with Health event volume |
@@ -325,13 +346,16 @@ This triggers the full flow: Event Router → Step Functions → DevOps Agent �
 | File | Scenario |
 |------|----------|
 | `events/sample-health-event.json` | EC2 scheduled maintenance |
+| `events/test-invoke-event.json` | Minimal EC2 scheduled maintenance (quick smoke test) |
 | `events/test-lambda-deprecation-event.json` | Lambda runtime EOL |
+| `events/test-lambda-nodejs20-lifecycle-event.json` | Lambda Node.js 20 planned lifecycle event |
 | `events/test-sfn-deprecation-event.json` | Step Functions deprecation |
 | `events/test-iam-admin-deprecation-event.json` | IAM admin role enforcement |
 | `events/test-security-event.json` | IAM overly permissive policies |
 | `events/test-lambda-throttle-event.json` | Lambda throttling |
 | `events/test-stepfunctions-issue-event.json` | Step Functions API errors |
 | `events/test-rds-ca-expiry-event.json` | RDS CA certificate expiry |
+| `events/test-opscenter-payload.json` | Direct OpsCenter Creator Lambda payload (not an Event Router event — invoke that function directly to test OpsItem creation in isolation) |
 
 ## Contributing
 

--- a/observability/proactive-health-event-impact-analyzer/README.md
+++ b/observability/proactive-health-event-impact-analyzer/README.md
@@ -77,11 +77,12 @@ An Agent Space monitors resources across *all* regions of an associated account,
 
 > **⚠️ Splitting the regions breaks the callback step.** `aws.aidevops` publishes investigation-completion events in the Agent Space region, but the EventBridge rule that resumes Step Functions lives in the deploy region — and EventBridge does not cross regions on its own. Keep both the same unless you have set up cross-region event forwarding. The wizard warns you when it detects a split.
 
-The [setup wizard](#deployment) handles everything else automatically:
+The [setup wizard](#deployment) handles everything else automatically via CDK
+(`DevOpsAgentSpaceStack` — see [ARCHITECTURE.md](./ARCHITECTURE.md#aws-devops-agent-provisioning)):
 - Creates the DevOps Agent Space and configures topology discovery
 - Creates IAM roles with correct trust policies
-- Generates the webhook for triggering investigations
-- Bootstraps and deploys the CDK stack
+- Generates the webhook for triggering investigations (HMAC secret stored directly in Secrets Manager)
+- Bootstraps and deploys the CDK stacks
 
 ## Deployment
 
@@ -96,15 +97,19 @@ npx ts-node scripts/setup-wizard.ts
 The wizard will:
 1. Prompt for target AWS region (always first)
 2. Check prerequisites (AWS CLI v2.34.20+, CDK, credentials)
-3. Create or select a DevOps Agent Space
-4. Create IAM roles (if needed)
-5. Associate your AWS account for topology discovery
-6. Generate a webhook for triggering investigations
-7. Enable the operator app
-8. (Optional) Register the Atlassian Jira MCP server and associate it with the Agent Space
-9. Configure notification channels (email, Slack, MS Teams)
-10. Store secrets in SSM Parameter Store SecureString
-11. Deploy the CDK stack with `--require-approval broadening`
+3. Configure notification channels (email, Slack, MS Teams) — optional
+4. Deploy the DevOps Agent Space stack (Agent Space, IAM roles, operator app,
+   AWS account association, and the eventChannel webhook — see
+   [ARCHITECTURE.md](./ARCHITECTURE.md#aws-devops-agent-provisioning)), then
+   read back its outputs and deploy the main stack with
+   `--require-approval broadening`
+5. (Optional) Register the Atlassian Jira MCP server and associate it with
+   the now-deployed Agent Space
+
+Steps 3–5 handle notification and Jira secrets: Slack/MS Teams webhook URLs go
+to SSM Parameter Store SecureString; the DevOps Agent webhook secret is
+written directly to Secrets Manager by CDK and never passes through this
+script.
 
 ### Cleanup
 
@@ -116,18 +121,46 @@ npx ts-node scripts/cleanup.ts
 
 ### Manual CDK Deployment
 
-> **Note**: The setup wizard is the recommended deployment path. Manual deployment requires you to create SSM SecureString parameters and IAM roles yourself.
+> **Note**: The setup wizard is the recommended deployment path. Manual deployment
+> means deploying two stacks in sequence and threading the first one's outputs
+> into the second's context yourself.
+
+The app now has two stacks: `HealthEventAnalyzerAgentSpace-<region>` (the
+DevOps Agent Space, IAM roles, operator app, account association, and
+webhook — see [ARCHITECTURE.md](./ARCHITECTURE.md#aws-devops-agent-provisioning))
+and `HealthEventAnalyzerStack-<region>` (everything else). Deploy the first,
+read its outputs, then deploy the second with those outputs as context:
 
 ```bash
 cd infrastructure/cdk
 npm install
 npm run bundle   # compiles the TypeScript Lambda handlers into dist/lambda/
-npx cdk deploy HealthEventAnalyzerStack-$AWS_REGION \
-  --parameters DevOpsAgentWebhookUrl=YOUR_URL \
+
+# 1. Deploy the DevOps Agent Space stack first.
+#    Add -c devOpsAgentRegion=eu-west-1 only if the Agent Space should live in
+#    a different Region than the main stack.
+npx cdk deploy HealthEventAnalyzerAgentSpace-$AWS_REGION \
   --no-cli-pager --require-approval broadening
 
-# Only if the Agent Space is in a different region than the stack:
-#   --parameters DevOpsAgentRegion=eu-west-1
+# 2. Read back its outputs. The webhook HMAC secret is never printed — only
+#    its Secrets Manager ARN is (the custom resource wrote the value directly
+#    into that secret during step 1).
+WEBHOOK_URL=$(aws cloudformation describe-stacks \
+  --stack-name HealthEventAnalyzerAgentSpace-$AWS_REGION \
+  --query "Stacks[0].Outputs[?OutputKey=='WebhookUrl'].OutputValue" --output text)
+WEBHOOK_SECRET_ARN=$(aws cloudformation describe-stacks \
+  --stack-name HealthEventAnalyzerAgentSpace-$AWS_REGION \
+  --query "Stacks[0].Outputs[?OutputKey=='WebhookSecretArn'].OutputValue" --output text)
+
+# 3. Deploy the main stack, passing those outputs as CDK context (there is no
+#    CloudFormation parameter for either value).
+npx cdk deploy HealthEventAnalyzerStack-$AWS_REGION \
+  -c devOpsAgentWebhookUrl=$WEBHOOK_URL \
+  -c devOpsAgentWebhookSecretArn=$WEBHOOK_SECRET_ARN \
+  --no-cli-pager --require-approval broadening
+
+# Only if the Agent Space is in a different region than the main stack:
+#   -c devOpsAgentRegion=eu-west-1  (on both the step-1 and step-3 commands)
 ```
 
 > **Note**: `npm run bundle` is required before any manual `cdk synth`/`cdk deploy`. The
@@ -135,11 +168,12 @@ npx cdk deploy HealthEventAnalyzerStack-$AWS_REGION \
 > with a missing-asset error if you skip it. The setup wizard and `deploy-all` scripts
 > run this step automatically, and `npm test` / `npm run build` run it via npm pre-hooks.
 
-Secrets (webhook secret, Slack URL, MS Teams URL) are stored in **SSM Parameter Store SecureString** — not passed as CloudFormation parameters. For manual deployment, create them before deploying:
+The Slack/MS Teams webhook URLs are still stored in **SSM Parameter Store
+SecureString** — not passed as CloudFormation parameters. For manual
+deployment, create them before deploying the main stack (unrelated to the
+DevOps Agent webhook secret above, which CDK provisions directly):
 
 ```bash
-aws ssm put-parameter --name "/health-analyzer/production/webhook-secret" \
-  --type SecureString --value "YOUR_HMAC_SECRET"
 aws ssm put-parameter --name "/health-analyzer/production/slack-webhook-url" \
   --type SecureString --value "https://hooks.slack.com/..."
 aws ssm put-parameter --name "/health-analyzer/production/msteams-webhook-url" \
@@ -229,8 +263,14 @@ Cost optimization: All resources use on-demand/pay-per-request pricing. No idle 
 
 ```
 ├── infrastructure/cdk/          # AWS CDK infrastructure (TypeScript)
-│   ├── bin/app.ts              # CDK app entry point
-│   ├── lib/                    # Stack and construct definitions
+│   ├── bin/app.ts              # CDK app entry point (both stacks)
+│   ├── lib/
+│   │   ├── health-event-analyzer-stack.ts   # Main stack
+│   │   ├── devops-agent-space-stack.ts      # DevOps Agent Space stack
+│   │   └── constructs/
+│   │       ├── devops-agent-space.ts        # Agent Space, IAM roles, operator
+│   │       │                                # app, account association, webhook
+│   │       └── ...                          # other stack constructs
 │   ├── scripts/
 │   │   └── bundle-lambdas.js   # esbuild pre-compile → dist/lambda/<name>/index.js
 │   └── lambda/                 # Lambda function source code
@@ -238,8 +278,11 @@ Cost optimization: All resources use on-demand/pay-per-request pricing. No idle 
 │       ├── investigation-trigger/  # HMAC webhook to DevOps Agent
 │       ├── investigation-callback/ # Handles agent completion
 │       ├── opscenter-creator/  # Creates OpsItem in Systems Manager OpsCenter
-│       └── notifier/           # Routes notifications to teams (incl. default
-│                               # routing via AWS Account alternate contacts)
+│       ├── notifier/           # Routes notifications to teams (incl. default
+│       │                       # routing via AWS Account alternate contacts)
+│       └── devops-agent-webhook-provisioner/  # Custom resource: provisions the
+│                                               # eventChannel webhook (see
+│                                               # ARCHITECTURE.md)
 ├── devops-agent-skill/         # DevOps Agent custom skill definition
 ├── scripts/                    # Setup wizard and utility scripts
 ├── events/                     # Sample events for testing

--- a/observability/proactive-health-event-impact-analyzer/deploy-all.ps1
+++ b/observability/proactive-health-event-impact-analyzer/deploy-all.ps1
@@ -6,11 +6,12 @@
 #   .\deploy-all.ps1 -SkipSetup   # Skip prerequisites, run wizard only
 #
 # The setup wizard handles:
-#   1. DevOps Agent Space creation and configuration
-#   2. IAM roles for topology discovery
-#   3. Webhook generation for investigation triggers
-#   4. Notification channel configuration (email, Slack, MS Teams)
-#   5. CDK stack deployment
+#   1. Notification channel configuration (email, Slack, MS Teams)
+#   2. Deploying the DevOps Agent Space stack (Agent Space, IAM roles,
+#      operator app, AWS account association, and the webhook — all via
+#      CDK L1 constructs; see ARCHITECTURE.md) and reading back its outputs
+#   3. Deploying the main CDK stack with those outputs as context
+#   4. (Optional) Atlassian Jira MCP integration, once the Agent Space exists
 
 param(
     [switch]$SkipSetup

--- a/observability/proactive-health-event-impact-analyzer/deploy-all.sh
+++ b/observability/proactive-health-event-impact-analyzer/deploy-all.sh
@@ -8,11 +8,12 @@
 #   ./deploy-all.sh --skip-setup # Skip prerequisites, run wizard only
 #
 # The setup wizard handles:
-#   1. DevOps Agent Space creation and configuration
-#   2. IAM roles for topology discovery
-#   3. Webhook generation for investigation triggers
-#   4. Notification channel configuration (email, Slack, MS Teams)
-#   5. CDK stack deployment
+#   1. Notification channel configuration (email, Slack, MS Teams)
+#   2. Deploying the DevOps Agent Space stack (Agent Space, IAM roles,
+#      operator app, AWS account association, and the webhook — all via
+#      CDK L1 constructs; see ARCHITECTURE.md) and reading back its outputs
+#   3. Deploying the main CDK stack with those outputs as context
+#   4. (Optional) Atlassian Jira MCP integration, once the Agent Space exists
 
 set -e
 

--- a/observability/proactive-health-event-impact-analyzer/docs/configuration-guide.md
+++ b/observability/proactive-health-event-impact-analyzer/docs/configuration-guide.md
@@ -12,7 +12,7 @@ The solution is production-hardened with the following security and operational 
 | Feature | Detail |
 |---------|--------|
 | **IAM least-privilege** | All policies scoped to specific resource ARNs; no wildcards where deterministic |
-| **Secrets management** | All secrets in SSM Parameter Store SecureString; fetched at runtime with 5-min cache |
+| **Secrets management** | DevOps Agent webhook secret in a CDK-managed Secrets Manager secret (written once by a provisioning custom resource); Slack/MS Teams webhook URLs in SSM Parameter Store SecureString — both fetched at runtime with 5-min cache, neither is a CloudFormation parameter |
 | **Encryption at rest** | DynamoDB (AWS owned key), SNS (KMS `alias/aws/sns`), CloudWatch Logs (AES-256) |
 | **Encryption in transit** | SNS topic denies non-SSL transport (`aws:SecureTransport` condition) |
 | **Dead letter queues** | 3 SQS DLQs for event-driven Lambdas (14-day retention, CloudWatch alarms) |
@@ -33,48 +33,38 @@ npx cdk deploy ... -c environment=staging      # 14-day logs, DESTROY, no deleti
 
 ## DevOps Agent Setup
 
-This solution relies on AWS DevOps Agent's topology for workload discovery — no manual workload configuration needed.
+This solution relies on AWS DevOps Agent's topology for workload discovery — no manual workload configuration needed. The Agent Space itself, its IAM roles, account association, operator app, and webhook are provisioned automatically by the `DevOpsAgentSpaceStack` CDK stack when you run the [setup wizard](../README.md#deployment) — there is no console setup for any of that. See [ARCHITECTURE.md](../ARCHITECTURE.md#aws-devops-agent-provisioning) for how the stack works, including why the webhook still needs a Lambda-backed custom resource.
 
-### Step 1: Create an Agent Space
+### Topology Discovery
 
-1. Open the [AWS DevOps Agent console](https://console.aws.amazon.com/devopsagent)
-2. Create a new Agent Space
-3. Connect your AWS account(s) for resource discovery
-
-### Step 2: Wait for Topology Discovery
-
-DevOps Agent automatically discovers resources through:
+Once the Agent Space and its AWS account association exist, DevOps Agent automatically discovers resources through:
 
 - **CloudFormation stacks** — all resources deployed via CloudFormation/CDK
 - **Resource Explorer** — tagged resources not in CloudFormation (enable Resource Explorer in your account)
 
-The initial topology scan takes a few minutes. You can verify it's complete in the Topology page of the Operator Web App.
+The initial topology scan takes a few minutes after deployment. You can verify it's complete in the Topology page of the Operator Web App.
 
-### Step 3: Configure a Generic Webhook
+### EventBridge Integration
 
-1. In your Agent Space, go to **Capabilities** → **Webhook**
-2. Click **Generate webhook** (creates HMAC credentials)
-3. Save the **webhook URL** and **HMAC secret** — you won't be able to retrieve the secret again
-4. The setup wizard stores the HMAC secret in SSM Parameter Store SecureString at `/health-analyzer/{env}/webhook-secret`
+DevOps Agent automatically sends events to the default EventBridge bus when investigations complete. No additional configuration needed — the main CDK stack creates the rule to capture `aws.aidevops` events.
 
-### Step 4: Verify EventBridge Integration
+## Deployment Configuration
 
-DevOps Agent automatically sends events to the default EventBridge bus when investigations complete. No additional configuration needed — the CDK stack creates the rule to capture `aws.aidevops` events.
+The DevOps Agent webhook URL and Secrets Manager secret ARN are **CDK context values**, not CloudFormation parameters — the setup wizard reads them from `DevOpsAgentSpaceStack`'s outputs and passes them with `-c devOpsAgentWebhookUrl=... -c devOpsAgentWebhookSecretArn=...` when it deploys the main stack (see the [manual deployment steps](../README.md#manual-cdk-deployment) if you're not using the wizard).
 
-## Deployment Parameters
-
-| Parameter | Required | Default | Description |
+| CDK Parameter/Context | Required | Default | Description |
 |-----------|----------|---------|-------------|
-| `DevOpsAgentWebhookUrl` | Yes | — | Generic webhook URL from DevOps Agent |
-| `NotificationEmail` | No | (empty) | Email for SNS notifications |
+| `NotificationEmail` (CFN parameter) | No | (empty) | Email for SNS notifications |
+| `devOpsAgentWebhookUrl` (context) | Yes | — | Generic webhook URL, from `DevOpsAgentSpaceStack`'s `WebhookUrl` output |
+| `devOpsAgentWebhookSecretArn` (context) | Yes | — | Secrets Manager ARN, from `DevOpsAgentSpaceStack`'s `WebhookSecretArn` output |
+| `devOpsAgentRegion` (context) | No | stack's own region | Region hosting the Agent Space, if different |
 
-### Secrets in SSM Parameter Store
+### Slack/MS Teams Secrets in SSM Parameter Store
 
-Secrets are **no longer passed as CloudFormation parameters**. They are stored in SSM Parameter Store SecureString and fetched by Lambda functions at runtime with caching (5-minute TTL).
+The DevOps Agent webhook secret is **not** an SSM parameter — it's a Secrets Manager secret managed entirely by CDK (see above). The Slack and MS Teams webhook URLs are still SSM Parameter Store SecureStrings, fetched by the Notifier Lambda at runtime with caching (5-minute TTL):
 
 | SSM Parameter Path | Consumer | Description |
 |---|---|---|
-| `/health-analyzer/{env}/webhook-secret` | Investigation Trigger Lambda | DevOps Agent HMAC secret |
 | `/health-analyzer/{env}/slack-webhook-url` | Notifier Lambda | Slack incoming webhook URL |
 | `/health-analyzer/{env}/msteams-webhook-url` | Notifier Lambda | MS Teams webhook URL |
 
@@ -83,15 +73,13 @@ Where `{env}` is `production` or `staging` based on the CDK context variable.
 The setup wizard creates these parameters automatically. For manual deployments:
 
 ```bash
-aws ssm put-parameter --name "/health-analyzer/production/webhook-secret" \
-  --type SecureString --value "YOUR_HMAC_SECRET" --overwrite
 aws ssm put-parameter --name "/health-analyzer/production/slack-webhook-url" \
   --type SecureString --value "https://hooks.slack.com/..." --overwrite
 aws ssm put-parameter --name "/health-analyzer/production/msteams-webhook-url" \
   --type SecureString --value "https://..." --overwrite
 ```
 
-> **Security**: Lambda environment variables contain only the SSM parameter *name* (path), never the secret value itself. IAM permissions are scoped to the specific parameter ARNs each Lambda needs.
+> **Security**: Lambda environment variables contain only the SSM parameter *name* (path) or Secrets Manager *ARN*, never a secret value itself. IAM permissions are scoped to the specific parameter/secret ARNs each Lambda needs.
 
 ## How Topology Replaces Static Config
 
@@ -188,7 +176,7 @@ Extend the `infrastructure/cdk/lambda/notifier/index.ts` to add:
 
 ### Jira (via DevOps Agent MCP Server)
 
-The DevOps Agent can auto-file Jira tickets when it detects MEDIUM+ impact. This is configured via the setup wizard (Step 7) or the `--jira-only` flag. The agent uses the Atlassian Rovo MCP Server to create and comment on tickets.
+The DevOps Agent can auto-file Jira tickets when it detects MEDIUM+ impact. This is configured via the setup wizard (the Atlassian Jira step, which runs after the CDK deployment step since it needs the deployed Agent Space) or the `--jira-only` flag. The agent uses the Atlassian Rovo MCP Server to create and comment on tickets.
 
 - Routing config (project key, issue type, site URL) stored in SSM: `/health-analyzer/jira/*`
 - Tickets are created only for severity ≥ MEDIUM

--- a/observability/proactive-health-event-impact-analyzer/docs/jira-integration.md
+++ b/observability/proactive-health-event-impact-analyzer/docs/jira-integration.md
@@ -159,11 +159,13 @@ If this is your **first** wizard run (no deployment yet), run the full flow:
 npx ts-node scripts/setup-wizard.ts
 ```
 
-Step 7 ("Atlassian Jira integration") is the new opt-in step.
+The Atlassian Jira integration is the final, opt-in step — it runs after
+the CDK deployment step, since it needs the Agent Space that step just
+created.
 
 If you've **already deployed** and just want to add the Jira integration
-to an existing Agent Space, use the focused flag — it skips IAM, webhook,
-operator app, notification channels, and the CDK deploy:
+to an existing Agent Space, use the focused flag — it skips prerequisites,
+notification channels, and the CDK deploy entirely:
 
 ```bash
 npx ts-node scripts/setup-wizard.ts --jira-only

--- a/observability/proactive-health-event-impact-analyzer/docs/multi-account-setup.md
+++ b/observability/proactive-health-event-impact-analyzer/docs/multi-account-setup.md
@@ -82,16 +82,22 @@ Deploy in the management account or a delegated admin account:
 npx ts-node scripts/setup-wizard.ts
 ```
 
-The setup wizard handles webhook URL, SSM secrets, and all parameters interactively. For manual deployment:
+The setup wizard deploys the DevOps Agent Space stack (creating the shared space's webhook automatically), then the main stack, threading the webhook URL and Secrets Manager secret ARN through as CDK context. For manual deployment, see [README.md § Manual CDK Deployment](../README.md#manual-cdk-deployment) for the full two-stack sequence; in short:
 
 ```bash
 cd infrastructure/cdk
+npx cdk deploy HealthEventAnalyzerAgentSpace-$AWS_REGION --require-approval=broadening
+WEBHOOK_URL=$(aws cloudformation describe-stacks --stack-name HealthEventAnalyzerAgentSpace-$AWS_REGION \
+  --query "Stacks[0].Outputs[?OutputKey=='WebhookUrl'].OutputValue" --output text)
+WEBHOOK_SECRET_ARN=$(aws cloudformation describe-stacks --stack-name HealthEventAnalyzerAgentSpace-$AWS_REGION \
+  --query "Stacks[0].Outputs[?OutputKey=='WebhookSecretArn'].OutputValue" --output text)
 npx cdk deploy HealthEventAnalyzerStack-$AWS_REGION \
-  --parameters DevOpsAgentWebhookUrl=YOUR_SHARED_SPACE_URL \
+  -c devOpsAgentWebhookUrl=$WEBHOOK_URL \
+  -c devOpsAgentWebhookSecretArn=$WEBHOOK_SECRET_ARN \
   --require-approval=broadening
 ```
 
-The webhook HMAC secret is stored in SSM Parameter Store SecureString at `/health-analyzer/{env}/webhook-secret` (created by the setup wizard or manually via `aws ssm put-parameter --type SecureString`).
+The shared space's webhook HMAC secret lives in the Secrets Manager secret CDK created above — it's never an SSM parameter and never passes through this deployment. (The **per-account override** webhook secrets described below, in the `health-analyzer-agent-spaces` table, are a separate mechanism and are still stored as plain DynamoDB item values — see the table schema.)
 
 ### Step 3: Configure Per-Account Agent Spaces (Optional)
 

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/bin/app.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/bin/app.ts
@@ -4,9 +4,16 @@ import { execSync } from 'child_process';
 import * as cdk from 'aws-cdk-lib';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { HealthEventAnalyzerStack } from '../lib/health-event-analyzer-stack';
+import { DevOpsAgentSpaceStack } from '../lib/devops-agent-space-stack';
 import { ProductionValidationAspect } from '../lib/aspects/production-validation';
 
 const app = new cdk.App();
+
+// Deployment environment — read here (not only inside HealthEventAnalyzerStack)
+// so DevOpsAgentSpaceStack, instantiated first, can size its log retention to
+// match the same 90d/14d rule the repo-wide ProductionValidationAspect enforces
+// below. HealthEventAnalyzerStack still validates this against VALID_ENVIRONMENTS.
+const environment = app.node.tryGetContext('environment') ?? 'production';
 
 // Region detection — priority order (matches shared/utils/aws-utils pattern):
 // 1. Environment variable (temporary override)
@@ -30,12 +37,39 @@ function getRegion(): string {
 
 const region = getRegion();
 
+// ─── DevOps Agent Space region ────────────────────────────────────────────────
+// May differ from the infra region — an Agent Space monitors resources across
+// ALL regions of the associated account, so it does not need to live with the
+// rest of the stack. Resolved from CDK context (`devOpsAgentRegion`), which
+// scripts/setup-wizard.ts sets from DEVOPS_AGENT_REGION before synthesizing.
+// See shared/README.md ("AWS DevOps Agent Region").
+const devOpsAgentRegion = app.node.tryGetContext('devOpsAgentRegion') || region;
+
+// DevOpsAgentSpaceStack — the Agent Space itself (roles, operator app, AWS
+// monitor association, eventChannel webhook). Deployed FIRST by the setup
+// wizard: its outputs (webhook URL + Secrets Manager ARN) are read back via
+// `aws cloudformation describe-stacks` and fed into the main stack below as
+// context. This replaces the imperative `aws devops-agent` CLI flow the
+// wizard used to drive by hand.
+const agentSpaceStack = new DevOpsAgentSpaceStack(app, `HealthEventAnalyzerAgentSpace-${devOpsAgentRegion}`, {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: devOpsAgentRegion,
+  },
+  projectName: 'health-event-analyzer',
+  deployEnvironment: environment,
+  description: 'Proactive Health Event Impact Analyzer - DevOps Agent Space stack (Agent Space, IAM roles, operator app, webhook)',
+});
+
 const stack = new HealthEventAnalyzerStack(app, `HealthEventAnalyzerStack-${region}`, {
   description: 'Proactive Health Event Impact Analyzer - GenAI-powered AWS Health event correlation and team notification (uksb-do9bhieqqh)(tag:health-event-analyzer,observability)',
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region,
   },
+  devOpsAgentWebhookUrl: app.node.tryGetContext('devOpsAgentWebhookUrl') ?? '',
+  devOpsAgentWebhookSecretArn: app.node.tryGetContext('devOpsAgentWebhookSecretArn') ?? '',
+  devOpsAgentRegion,
 });
 
 // ─── CDK Nag: AWS Solutions rule pack (Requirement 15.2) ──────────────────────
@@ -76,5 +110,25 @@ NagSuppressions.addStackSuppressions(stack, [
   {
     id: 'AwsSolutions-SQS4',
     reason: 'SQS dead letter queues receive messages from Lambda async invocation failures via internal AWS service integration. SSL enforcement on these DLQs is not applicable as messages are published by the Lambda service, not user-initiated API calls.',
+  },
+], true);
+
+// ─── CDK Nag Suppressions — DevOps Agent Space stack ───────────────────────────
+NagSuppressions.addStackSuppressions(agentSpaceStack, [
+  {
+    id: 'AwsSolutions-IAM4',
+    reason: 'AIDevOpsAgentAccessPolicy and AIDevOpsOperatorAppAccessPolicy are AWS managed policies published specifically for AWS DevOps Agent — there is no customer-managed equivalent, and AWS documents these as the required grant for the service to assume a monitoring/operator role. AWSLambdaBasicExecutionRole on the webhook provisioner Lambda is the standard CDK-generated execution role for CloudWatch Logs access.',
+  },
+  {
+    id: 'AwsSolutions-IAM5',
+    reason: 'Wildcards are required: the aidevops:RegisterService/ListServices/AssociateService/DisassociateService/ListAssociations calls the webhook provisioner Lambda makes are account-level APIs with no resource-level ARN in their request (RegisterService especially has no space/service id yet to scope to); iam:CreateServiceLinkedRole is scoped to the aws-service-role/* path, which is the finest grain IAM supports for SLR creation; and the Secrets Manager grantWrite() on the webhook secret appends AWS\'s own wildcard version suffix to an otherwise fully-scoped secret ARN.',
+  },
+  {
+    id: 'AwsSolutions-L1',
+    reason: 'Lambda runtime NODEJS_24_X is the latest LTS runtime. CDK Nag may not yet recognize it as the latest if its rule set lags behind AWS runtime releases.',
+  },
+  {
+    id: 'AwsSolutions-SMG4',
+    reason: 'This secret holds the DevOps Agent webhook HMAC key, written exactly once by the provisioning custom resource from AssociateService\'s one-time response and read only via GetSecretValue. There is no DevOps Agent rotation API for this value — the only way to rotate it is to replace the association (delete + recreate the webhook), which the custom resource already does on any property change. Automatic Secrets Manager rotation would silently desynchronize the stored value from the live webhook.',
   },
 ], true);

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/devops-agent-webhook-provisioner/index.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/devops-agent-webhook-provisioner/index.ts
@@ -1,0 +1,267 @@
+import {
+  AssociateServiceCommand,
+  DevOpsAgentClient,
+  DisassociateServiceCommand,
+  ListAssociationsCommand,
+  ListServicesCommand,
+  RegisterServiceCommand,
+} from '@aws-sdk/client-devops-agent';
+import {
+  PutSecretValueCommand,
+  SecretsManagerClient,
+} from '@aws-sdk/client-secrets-manager';
+
+/**
+ * Lambda-backed CloudFormation custom resource that provisions a DevOps Agent
+ * eventChannel webhook.
+ *
+ * Why a custom resource is unavoidable:
+ * - AWS::DevOpsAgent::Service cannot register the eventChannel service type.
+ * - AWS::DevOpsAgent::Association exposes no webhook URL or HMAC secret.
+ * - AssociateService returns the secret exactly once, in its create response.
+ *
+ * The secret is written directly to Secrets Manager and is NEVER returned to
+ * CloudFormation. Data contains only WebhookUrl; PhysicalResourceId is the
+ * association id.
+ */
+
+interface CustomResourceEvent {
+  RequestType: 'Create' | 'Update' | 'Delete';
+  ResponseURL: string;
+  StackId: string;
+  RequestId: string;
+  ResourceType: string;
+  LogicalResourceId: string;
+  PhysicalResourceId?: string;
+  ResourceProperties: {
+    ServiceToken: string;
+    AgentSpaceId: string;
+    SecretArn: string;
+  };
+}
+
+interface LambdaContext {
+  logStreamName: string;
+}
+
+const devOpsAgent = new DevOpsAgentClient({});
+const secretsManager = new SecretsManagerClient({});
+const SERVICE_TYPE = 'eventChannel' as const;
+
+class WebhookProvisioningError extends Error {
+  constructor(message: string, readonly associationId: string) {
+    super(message);
+    this.name = 'WebhookProvisioningError';
+  }
+}
+
+export async function handler(event: CustomResourceEvent, context: LambdaContext): Promise<void> {
+  // ResponseURL is a bearer URL — never log it.
+  const { ResponseURL: _responseUrl, ...safeEvent } = event;
+  console.info('Request', JSON.stringify(safeEvent));
+
+  let physicalResourceId = event.PhysicalResourceId ?? 'failed';
+  try {
+    if (event.RequestType === 'Create' || event.RequestType === 'Update') {
+      const result = await createWebhook(
+        event.ResourceProperties.AgentSpaceId,
+        event.ResourceProperties.SecretArn,
+      );
+      physicalResourceId = result.associationId;
+      await respond(event, context, 'SUCCESS', physicalResourceId, {
+        WebhookUrl: result.webhookUrl,
+      });
+      return;
+    }
+
+    await deleteWebhook(
+      event.ResourceProperties.AgentSpaceId,
+      event.PhysicalResourceId,
+    );
+    await respond(event, context, 'SUCCESS', event.PhysicalResourceId ?? 'deleted');
+  } catch (error) {
+    if (error instanceof WebhookProvisioningError) {
+      // Compensation failed, so preserve the live association id. A subsequent
+      // CloudFormation rollback DELETE can retry disassociating it.
+      physicalResourceId = error.associationId;
+    }
+    console.error('Webhook provisioning failed', error);
+    await respond(
+      event,
+      context,
+      'FAILED',
+      physicalResourceId,
+      undefined,
+      error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+    );
+  }
+}
+
+async function createWebhook(
+  agentSpaceId: string,
+  secretArn: string,
+): Promise<{ associationId: string; webhookUrl: string }> {
+  const serviceId = await ensureEventChannelService();
+
+  // The create response is the one and only carrier of webhookSecret.
+  const association = await devOpsAgent.send(new AssociateServiceCommand({
+    agentSpaceId,
+    serviceId,
+    configuration: { eventChannel: {} },
+  }));
+
+  let associationId = association.association?.associationId;
+  const webhookUrl = association.webhook?.webhookUrl;
+  const webhookSecret = association.webhook?.webhookSecret;
+
+  // The modeled response includes association.associationId, but recover it by
+  // service id if the service returns a partial response. We need the id both for
+  // normal ownership and for compensating rollback.
+  if (!associationId) {
+    const existing = await devOpsAgent.send(new ListAssociationsCommand({ agentSpaceId }));
+    associationId = existing.associations?.find((item) => item.serviceId === serviceId)?.associationId;
+  }
+
+  if (!associationId) {
+    throw new Error('AssociateService succeeded but no association id could be recovered');
+  }
+
+  try {
+    if (!webhookUrl || !webhookSecret) {
+      throw new Error(
+        'AssociateService did not return complete webhook credentials '
+        + `(url=${webhookUrl ? 'present' : 'MISSING'}, `
+        + `secret=${webhookSecret ? 'present' : 'MISSING'})`,
+      );
+    }
+
+    // Persist before returning anything to CloudFormation. The value never enters
+    // CFN state, events, outputs, or Lambda environment variables.
+    await secretsManager.send(new PutSecretValueCommand({
+      SecretId: secretArn,
+      SecretString: webhookSecret,
+    }));
+  } catch (error) {
+    // AssociateService already created a live webhook whose secret cannot be
+    // recovered later. Compensate immediately. If compensation itself fails,
+    // preserve the association id in the thrown error so CFN rollback can retry.
+    try {
+      await disassociate(agentSpaceId, associationId);
+      console.info('Compensated partial webhook creation', { associationId });
+    } catch (cleanupError) {
+      throw new WebhookProvisioningError(
+        `Webhook setup failed and compensating disassociation also failed: ${formatError(cleanupError)}`,
+        associationId,
+      );
+    }
+    throw error;
+  }
+
+  console.info('Webhook created; secret stored', { associationId });
+  return { associationId, webhookUrl };
+}
+
+async function ensureEventChannelService(): Promise<string> {
+  try {
+    const registered = await devOpsAgent.send(new RegisterServiceCommand({
+      service: SERVICE_TYPE,
+      serviceDetails: { eventChannel: {} },
+    }));
+    if (registered.serviceId) {
+      console.info('Registered eventChannel service', { serviceId: registered.serviceId });
+      return registered.serviceId;
+    }
+  } catch (error) {
+    // Registration is account-level and may already exist from a previous run.
+    console.info('RegisterService failed; looking for an existing eventChannel registration', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  let nextToken: string | undefined;
+  do {
+    const page = await devOpsAgent.send(new ListServicesCommand({
+      filterServiceType: SERVICE_TYPE,
+      nextToken,
+    }));
+    const match = page.services?.find((service) => service.serviceType === SERVICE_TYPE);
+    if (match?.serviceId) {
+      console.info('Reusing existing eventChannel service', { serviceId: match.serviceId });
+      return match.serviceId;
+    }
+    nextToken = page.nextToken;
+  } while (nextToken);
+
+  throw new Error('Could not register or locate the account-level eventChannel service');
+}
+
+async function deleteWebhook(
+  agentSpaceId: string | undefined,
+  associationId: string | undefined,
+): Promise<void> {
+  if (!agentSpaceId || !associationId || ['failed', 'deleted', 'unknown'].includes(associationId)) {
+    console.info('Nothing to delete', { agentSpaceId, associationId });
+    return;
+  }
+
+  try {
+    await disassociate(agentSpaceId, associationId);
+    console.info('Webhook association deleted', { associationId });
+  } catch (error) {
+    if (isNotFound(error)) {
+      console.info('Webhook association already absent', { associationId });
+      return;
+    }
+    // Access denial, throttling, service outage, and malformed requests must fail
+    // closed so CloudFormation keeps ownership and can retry the deletion.
+    throw error;
+  }
+}
+
+async function disassociate(agentSpaceId: string, associationId: string): Promise<void> {
+  await devOpsAgent.send(new DisassociateServiceCommand({ agentSpaceId, associationId }));
+}
+
+function isNotFound(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const candidate = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return candidate.name === 'ResourceNotFoundException'
+    || candidate.name === 'NotFoundException'
+    || candidate.$metadata?.httpStatusCode === 404;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+async function respond(
+  event: CustomResourceEvent,
+  context: LambdaContext,
+  status: 'SUCCESS' | 'FAILED',
+  physicalResourceId: string,
+  data: Record<string, string> = {},
+  reason?: string,
+): Promise<void> {
+  const body = JSON.stringify({
+    Status: status,
+    Reason: reason ?? `See CloudWatch log stream ${context.logStreamName}`,
+    PhysicalResourceId: physicalResourceId,
+    StackId: event.StackId,
+    RequestId: event.RequestId,
+    LogicalResourceId: event.LogicalResourceId,
+    Data: data,
+  });
+
+  const response = await fetch(event.ResponseURL, {
+    method: 'PUT',
+    headers: {
+      'content-type': '',
+      'content-length': Buffer.byteLength(body).toString(),
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    throw new Error(`CloudFormation response upload failed: ${response.status} ${response.statusText}`);
+  }
+}

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/devops-agent-webhook-provisioner/package.json
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/devops-agent-webhook-provisioner/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "devops-agent-webhook-provisioner",
+  "version": "1.0.0",
+  "description": "CloudFormation custom resource: provisions the DevOps Agent eventChannel webhook",
+  "main": "index.js",
+  "scripts": {
+    "build": "esbuild index.ts --bundle --platform=node --target=node24 --outfile=index.js"
+  },
+  "dependencies": {
+    "@aws-sdk/client-devops-agent": "^3.1053.0",
+    "@aws-sdk/client-secrets-manager": "^3.1053.0"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.140",
+    "esbuild": "^0.21.0",
+    "typescript": "~5.4.5"
+  }
+}

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/investigation-trigger/index.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/investigation-trigger/index.ts
@@ -3,12 +3,19 @@ import * as https from 'https';
 import * as url from 'url';
 import { DynamoDBClient, PutItemCommand, GetItemCommand } from '@aws-sdk/client-dynamodb';
 import { SSMClient, GetParametersCommand } from '@aws-sdk/client-ssm';
-import { getSecret } from '../lib/secrets-cache';
+import { getSecretFromSecretsManager } from '../lib/secrets-manager-cache';
 
 const dynamoClient = new DynamoDBClient({});
 const ssmClient = new SSMClient({});
 const DEFAULT_WEBHOOK_URL = process.env.DEVOPS_AGENT_WEBHOOK_URL!;
-const WEBHOOK_SECRET_PARAM_NAME = process.env.WEBHOOK_SECRET_PARAM_NAME!;
+// The webhook HMAC secret is provisioned by the CDK-managed DevOpsAgentSpace
+// construct into Secrets Manager (see lib/constructs/devops-agent-space.ts) —
+// it never passes through CloudFormation, so this Lambda reads it directly by
+// ARN. The secret may live in a different region than this function (an
+// Agent Space can be deployed to a different region than the main stack),
+// hence the separate region env var.
+const WEBHOOK_SECRET_ARN = process.env.WEBHOOK_SECRET_ARN!;
+const WEBHOOK_SECRET_REGION = process.env.WEBHOOK_SECRET_REGION || process.env.AWS_REGION!;
 const TASK_TOKEN_TABLE = process.env.TASK_TOKEN_TABLE!;
 const AGENT_SPACES_TABLE = process.env.AGENT_SPACES_TABLE || '';
 
@@ -149,8 +156,8 @@ export const handler = async (event: TriggerInput): Promise<void> => {
  * while supporting per-account overrides for teams that need isolation.
  */
 async function resolveAgentSpace(sourceAccountId?: string): Promise<AgentSpaceConfig> {
-  // Retrieve the default webhook secret from SSM via the cached secrets module
-  const defaultSecret = await getSecret(WEBHOOK_SECRET_PARAM_NAME);
+  // Retrieve the default webhook secret from Secrets Manager via the cached module
+  const defaultSecret = await getSecretFromSecretsManager(WEBHOOK_SECRET_ARN, WEBHOOK_SECRET_REGION);
 
   // If no agent spaces table configured or no source account, use default
   if (!AGENT_SPACES_TABLE || !sourceAccountId) {

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/investigation-trigger/package.json
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/investigation-trigger/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.600.0",
+    "@aws-sdk/client-secrets-manager": "^3.600.0",
     "@aws-sdk/client-ssm": "^3.600.0"
   },
   "devDependencies": {

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/lib/secrets-manager-cache.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lambda/lib/secrets-manager-cache.ts
@@ -1,0 +1,123 @@
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+
+/**
+ * In-memory cache for AWS Secrets Manager secrets, keyed by secret ARN.
+ *
+ * Used for the DevOps Agent webhook HMAC secret specifically. That secret is
+ * now provisioned by the CDK-managed DevOpsAgentSpace construct (see
+ * lib/constructs/devops-agent-space.ts) into a Secrets Manager secret whose
+ * value never passes through CloudFormation — as opposed to the Slack/MS
+ * Teams webhook URLs, which remain plain SSM Parameter Store SecureStrings
+ * (see secrets-cache.ts) since those are unrelated to the DevOps Agent
+ * CLI-to-CDK migration.
+ *
+ * The secret may live in a different region than the Lambda consuming it —
+ * an Agent Space (and its webhook secret) can be deployed to a different
+ * region than the main stack. Each cache entry therefore carries its own
+ * region-scoped client.
+ */
+export interface SecretsManagerCacheConfig {
+  /** Cache TTL in milliseconds. Minimum 300000 (5 minutes). */
+  cacheTtlMs: number;
+}
+
+interface CachedSecret {
+  value: string;
+  fetchedAt: number;
+}
+
+const MIN_TTL_MS = 300_000; // 5 minutes
+
+const DEFAULT_CONFIG: SecretsManagerCacheConfig = {
+  cacheTtlMs: MIN_TTL_MS,
+};
+
+const cache = new Map<string, CachedSecret>();
+const clients = new Map<string, SecretsManagerClient>();
+
+let config: SecretsManagerCacheConfig = { ...DEFAULT_CONFIG };
+
+/**
+ * Configure the secrets cache. The TTL is clamped to a minimum of 5 minutes.
+ */
+export function configureSecretsManagerCache(options: Partial<SecretsManagerCacheConfig>): void {
+  config = {
+    cacheTtlMs: Math.max(options.cacheTtlMs ?? DEFAULT_CONFIG.cacheTtlMs, MIN_TTL_MS),
+  };
+}
+
+function getClient(region: string): SecretsManagerClient {
+  let client = clients.get(region);
+  if (!client) {
+    client = new SecretsManagerClient({ region });
+    clients.set(region, client);
+  }
+  return client;
+}
+
+/**
+ * Retrieve a secret from AWS Secrets Manager with in-memory caching.
+ *
+ * On cache hit within the TTL window, returns the cached value without
+ * making a Secrets Manager API call. After TTL expiry, fetches a fresh value.
+ *
+ * Error messages include the secret ARN but never expose the secret value.
+ *
+ * @param secretArn - The Secrets Manager secret ARN
+ * @param region - Region containing the secret (may differ from the caller's own region)
+ * @returns The decrypted secret string
+ * @throws Error if the secret cannot be retrieved
+ */
+export async function getSecretFromSecretsManager(secretArn: string, region: string): Promise<string> {
+  const now = Date.now();
+  const cacheKey = `${region}:${secretArn}`;
+  const cached = cache.get(cacheKey);
+
+  if (cached && (now - cached.fetchedAt) < config.cacheTtlMs) {
+    return cached.value;
+  }
+
+  try {
+    const response = await getClient(region).send(
+      new GetSecretValueCommand({ SecretId: secretArn })
+    );
+
+    const value = response.SecretString;
+    if (value === undefined || value === null) {
+      throw new Error(`Secrets Manager secret "${secretArn}" returned no string value`);
+    }
+
+    cache.set(cacheKey, { value, fetchedAt: now });
+    return value;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes(secretArn)) {
+      throw error;
+    }
+    throw new Error(`Failed to retrieve Secrets Manager secret "${secretArn}": ${message}`);
+  }
+}
+
+/**
+ * Clear the secrets cache. Useful for testing or forced refresh.
+ */
+export function clearSecretsManagerCache(): void {
+  cache.clear();
+}
+
+/**
+ * Reset the secrets cache module entirely (cache + config + clients).
+ * Primarily used in tests.
+ */
+export function resetSecretsManagerCache(): void {
+  cache.clear();
+  clients.clear();
+  config = { ...DEFAULT_CONFIG };
+}
+
+/**
+ * Inject a custom Secrets Manager client for a given region (for testing).
+ */
+export function setSecretsManagerClient(region: string, client: SecretsManagerClient): void {
+  clients.set(region, client);
+}

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/devops-agent-space.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/devops-agent-space.ts
@@ -1,0 +1,261 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as devopsagent from 'aws-cdk-lib/aws-devopsagent';
+import { Construct } from 'constructs';
+import * as path from 'path';
+
+/**
+ * DevOpsAgentSpace — a reusable construct that provisions a complete, ready-to-use
+ * AWS DevOps Agent Agent Space:
+ *
+ *   1. AgentSpaceRole  — assumed by the DevOps Agent service to monitor the account
+ *                        (AIDevOpsAgentAccessPolicy + Resource Explorer SLR creation)
+ *   2. OperatorRole    — assumed for the operator app / web console
+ *                        (AIDevOpsOperatorAppAccessPolicy)
+ *   3. Agent Space     — AWS::DevOpsAgent::AgentSpace, operator app enabled (IAM auth)
+ *   4. AWS association — AWS::DevOpsAgent::Association (accountType "monitor"),
+ *                        wiring the account's resources into the space's topology
+ *   5. Webhook         — a generic eventChannel webhook for triggering investigations,
+ *                        provisioned by a Lambda-backed custom resource (see below)
+ *
+ * Why the webhook needs a custom resource
+ * ---------------------------------------
+ * The webhook's HMAC secret is returned ONLY in the AssociateService create response —
+ * no Describe/List API ever returns it again, and AWS::DevOpsAgent::Association exposes
+ * no webhook attributes. CloudFormation therefore cannot surface the secret. The custom
+ * resource performs RegisterService(eventChannel) + AssociateService at deploy time,
+ * writes the secret straight into a Secrets Manager secret (it never enters
+ * CloudFormation state or outputs), and returns only the webhook URL.
+ * (RegisterService also cannot be expressed in CloudFormation: AWS::DevOpsAgent::Service
+ * has no eventChannel service details type.)
+ *
+ * Any property change on the custom resource rotates the webhook (replacement =
+ * delete + recreate), which is the only correct behavior given the secret cannot
+ * be re-read.
+ *
+ * This mirrors the equivalent construct in observability/eks-investigation-devops-agent
+ * (lib/constructs/devops-agent-space.ts), which the maintainers already reviewed and
+ * merged for the same purpose — replacing the imperative `aws devops-agent` CLI flow
+ * that scripts/setup-wizard.ts previously drove by hand.
+ */
+export interface DevOpsAgentSpaceProps {
+  /** Agent Space name. Also used as the prefix for the two IAM role names. */
+  readonly name: string;
+
+  /** Human-readable description shown in the DevOps Agent console. */
+  readonly description?: string;
+
+  /**
+   * Deployment environment — drives the webhook provisioner Lambda's log
+   * retention (production=90d, non-production=14d), matching the repo-wide
+   * ProductionValidationAspect enforced in bin/app.ts across every stack.
+   */
+  readonly deployEnvironment: string;
+
+  /**
+   * AWS account to associate for monitoring. Defaults to the containing stack's
+   * account. The DevOps Agent discovers and maps resources across ALL regions of
+   * this account — no per-region association is needed.
+   */
+  readonly monitorAccountId?: string;
+
+  /**
+   * Enable the operator app (web console, IAM auth). Default: true.
+   */
+  readonly enableOperatorApp?: boolean;
+
+  /**
+   * Provision the generic eventChannel webhook (URL + HMAC secret in Secrets
+   * Manager). Default: true.
+   */
+  readonly enableWebhook?: boolean;
+}
+
+export class DevOpsAgentSpace extends Construct {
+  /** The underlying AWS::DevOpsAgent::AgentSpace resource. */
+  public readonly agentSpace: devopsagent.CfnAgentSpace;
+  /** Agent Space ID (CFN token). */
+  public readonly agentSpaceId: string;
+  /** Agent Space ARN (CFN token). */
+  public readonly agentSpaceArn: string;
+  /** Monitoring role the DevOps Agent assumes to inspect the account. */
+  public readonly agentSpaceRole: iam.Role;
+  /** Operator app (web console) role. */
+  public readonly operatorRole: iam.Role;
+  /**
+   * Webhook URL for triggering investigations (CFN token).
+   * Empty string when `enableWebhook` is false.
+   */
+  public readonly webhookUrl: string;
+  /**
+   * Secrets Manager secret holding the webhook HMAC secret. The value is written
+   * by the provisioner Lambda during deployment — it never passes through
+   * CloudFormation parameters, outputs, or resource state.
+   * Undefined when `enableWebhook` is false.
+   */
+  public readonly webhookSecret?: secretsmanager.Secret;
+
+  constructor(scope: Construct, id: string, props: DevOpsAgentSpaceProps) {
+    super(scope, id);
+
+    const stack = cdk.Stack.of(this);
+    const monitorAccountId = props.monitorAccountId ?? stack.account;
+    const enableOperatorApp = props.enableOperatorApp ?? true;
+    const enableWebhook = props.enableWebhook ?? true;
+
+    // ─── Trust policy shared by both roles ─────────────────────────────────
+    // aidevops.amazonaws.com, scoped to this account and to Agent Spaces in
+    // this region (ArnLike on aws:SourceArn). Matches the trust the AWS CLI
+    // onboarding flow (previously driven by scripts/setup-wizard.ts) established.
+    const aidevopsTrustConditions = {
+      StringEquals: { 'aws:SourceAccount': stack.account },
+      ArnLike: {
+        'aws:SourceArn': `arn:${stack.partition}:aidevops:${stack.region}:${stack.account}:agentspace/*`,
+      },
+    };
+    const aidevopsTrust = () =>
+      new iam.ServicePrincipal('aidevops.amazonaws.com').withConditions(aidevopsTrustConditions);
+    const addTagSessionTrust = (role: iam.Role) => {
+      role.assumeRolePolicy?.addStatements(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['sts:TagSession'],
+        principals: [aidevopsTrust()],
+      }));
+    };
+
+    // ─── 1. Monitoring role ────────────────────────────────────────────────
+    this.agentSpaceRole = new iam.Role(this, 'AgentSpaceRole', {
+      roleName: `${props.name}-AgentSpaceRole`,
+      assumedBy: aidevopsTrust(),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('AIDevOpsAgentAccessPolicy'),
+      ],
+      description: `Monitoring role assumed by AWS DevOps Agent for Agent Space '${props.name}'`,
+    });
+    addTagSessionTrust(this.agentSpaceRole);
+
+    // The agent creates the Resource Explorer service-linked role on first
+    // topology discovery. Scoped to SLR paths only.
+    this.agentSpaceRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'AllowCreateServiceLinkedRoles',
+      effect: iam.Effect.ALLOW,
+      actions: ['iam:CreateServiceLinkedRole'],
+      resources: [`arn:${stack.partition}:iam::${stack.account}:role/aws-service-role/*`],
+    }));
+
+    // ─── 2. Operator app role ──────────────────────────────────────────────
+    this.operatorRole = new iam.Role(this, 'OperatorRole', {
+      roleName: `${props.name}-OperatorRole`,
+      assumedBy: aidevopsTrust(),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('AIDevOpsOperatorAppAccessPolicy'),
+      ],
+      description: `Operator app (web console) role for Agent Space '${props.name}'`,
+    });
+    addTagSessionTrust(this.operatorRole);
+
+    // ─── 3. Agent Space ────────────────────────────────────────────────────
+    this.agentSpace = new devopsagent.CfnAgentSpace(this, 'AgentSpace', {
+      name: props.name,
+      description: props.description,
+      ...(enableOperatorApp ? {
+        operatorApp: {
+          iam: { operatorAppRoleArn: this.operatorRole.roleArn },
+        },
+      } : {}),
+    });
+    // Roles (and their policies) must be fully in place first: the service
+    // validates assumability during resource creation, and IAM is eventually
+    // consistent — the same class of race the wizard's retry-with-backoff loop
+    // used to work around for `associate-service`.
+    this.agentSpace.node.addDependency(this.agentSpaceRole);
+    this.agentSpace.node.addDependency(this.operatorRole);
+
+    this.agentSpaceId = this.agentSpace.attrAgentSpaceId;
+    this.agentSpaceArn = this.agentSpace.attrArn;
+
+    // ─── 4. AWS account association (monitor) ──────────────────────────────
+    const awsAssociation = new devopsagent.CfnAssociation(this, 'AwsMonitorAssociation', {
+      agentSpaceId: this.agentSpaceId,
+      // For Aws/SourceAws configurations the service id is the literal "aws".
+      serviceId: 'aws',
+      configuration: {
+        aws: {
+          accountId: monitorAccountId,
+          accountType: 'monitor',
+          assumableRoleArn: this.agentSpaceRole.roleArn,
+        },
+      },
+    });
+    awsAssociation.node.addDependency(this.agentSpaceRole);
+
+    // ─── 5. Webhook (custom resource) ──────────────────────────────────────
+    if (!enableWebhook) {
+      this.webhookUrl = '';
+      return;
+    }
+
+    // Holds the HMAC secret. No explicit name: avoids collisions with
+    // scheduled-deletion name retention on destroy/redeploy cycles.
+    this.webhookSecret = new secretsmanager.Secret(this, 'WebhookSecret', {
+      description: `DevOps Agent webhook HMAC secret for Agent Space '${props.name}'`,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
+    const provisionerFn = new lambda.Function(this, 'WebhookProvisioner', {
+      runtime: lambda.Runtime.NODEJS_24_X,
+      handler: 'index.handler',
+      // Pre-bundled by `npm run bundle` (scripts/bundle-lambdas.js).
+      // @aws-sdk/client-devops-agent and @aws-sdk/client-secrets-manager are
+      // bundled into the artifact rather than left external, since the newer
+      // devops-agent client is not guaranteed to ship with the Lambda runtime.
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, '..', '..', 'dist', 'lambda', 'devops-agent-webhook-provisioner'),
+      ),
+      timeout: cdk.Duration.minutes(2),
+      description: 'Custom resource: provisions the DevOps Agent eventChannel webhook and stores its HMAC secret in Secrets Manager',
+      logGroup: new logs.LogGroup(this, 'WebhookProvisionerLogs', {
+        // Matches the 90d/14d rule the repo-wide ProductionValidationAspect
+        // enforces across every stack (see bin/app.ts, lib/aspects/production-validation.ts).
+        retention: props.deployEnvironment === 'production'
+          ? logs.RetentionDays.THREE_MONTHS
+          : logs.RetentionDays.TWO_WEEKS,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+      }),
+    });
+
+    // RegisterService/ListServices are account-scoped calls without a resource
+    // ARN in their request; AssociateService/DisassociateService target the
+    // space and a generated service id. The aidevops resource-level scoping for
+    // these registration APIs is not documented, so this statement uses '*'
+    // with the actions enumerated tightly.
+    provisionerFn.addToRolePolicy(new iam.PolicyStatement({
+      sid: 'DevOpsAgentWebhookLifecycle',
+      effect: iam.Effect.ALLOW,
+      actions: [
+        'aidevops:RegisterService',
+        'aidevops:ListServices',
+        'aidevops:AssociateService',
+        'aidevops:DisassociateService',
+        'aidevops:ListAssociations',
+      ],
+      resources: ['*'],
+    }));
+    this.webhookSecret.grantWrite(provisionerFn);
+
+    const webhook = new cdk.CustomResource(this, 'Webhook', {
+      resourceType: 'Custom::DevOpsAgentWebhook',
+      serviceToken: provisionerFn.functionArn,
+      properties: {
+        AgentSpaceId: this.agentSpaceId,
+        SecretArn: this.webhookSecret.secretArn,
+      },
+    });
+    webhook.node.addDependency(this.agentSpace);
+
+    this.webhookUrl = webhook.getAttString('WebhookUrl');
+  }
+}

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/investigation-workflow.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/constructs/investigation-workflow.ts
@@ -12,6 +12,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaDestinations from 'aws-cdk-lib/aws-lambda-destinations';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as cloudwatch_actions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import * as path from 'path';
@@ -25,11 +26,19 @@ export interface InvestigationWorkflowProps {
    * Region hosting the DevOps Agent Agent Space. May differ from the stack region:
    * the service is only available in a subset of Regions, and an Agent Space monitors
    * resources across ALL Regions of an associated account. Used for the aidevops
-   * client region and IAM resource scoping in the callback Lambda.
+   * client region, the webhook secret's region, and IAM resource scoping in the
+   * callback Lambda.
    */
   devOpsAgentRegion: string;
-  /** SSM Parameter Store name for the webhook HMAC secret */
-  webhookSecretParamName: string;
+  /**
+   * ARN of the Secrets Manager secret holding the DevOps Agent webhook HMAC
+   * secret. Provisioned by the CDK-managed DevOpsAgentSpaceStack (see
+   * lib/devops-agent-space-stack.ts) — the value never passes through
+   * CloudFormation. Empty string when not yet configured (e.g. a bare
+   * `cdk synth` / `npm test` with no context supplied), in which case a
+   * placeholder secret name is imported instead so synthesis still succeeds.
+   */
+  devOpsAgentWebhookSecretArn: string;
   /** SSM Parameter Store name for the Slack webhook URL */
   slackWebhookParamName: string;
   /** SSM Parameter Store name for the MS Teams webhook URL */
@@ -71,6 +80,27 @@ export class InvestigationWorkflow extends Construct {
     const distDir = path.join(__dirname, '../../dist/lambda');
     const lambdaCode = (name: string) => lambda.Code.fromAsset(path.join(distDir, name));
 
+    // Import the webhook secret provisioned by DevOpsAgentSpaceStack. The secret
+    // may live in a different region than this stack (an Agent Space can be
+    // deployed to a different region — see props.devOpsAgentRegion), so the
+    // trigger Lambda below is given that region explicitly and creates its own
+    // Secrets Manager client scoped to it. When no ARN is supplied yet (e.g. a
+    // bare `cdk synth`/`npm test` before the Agent Space stack has ever been
+    // deployed), a placeholder secret name is imported instead so synthesis
+    // still succeeds — the deployed Lambda will simply fail to read it until a
+    // real ARN is passed.
+    const devOpsAgentWebhookSecret = props.devOpsAgentWebhookSecretArn
+      ? secretsmanager.Secret.fromSecretCompleteArn(
+          this,
+          'ImportedDevOpsAgentWebhookSecret',
+          props.devOpsAgentWebhookSecretArn,
+        )
+      : secretsmanager.Secret.fromSecretNameV2(
+          this,
+          'UnconfiguredDevOpsAgentWebhookSecret',
+          `health-event-analyzer-${props.deployEnvironment}/NOT_CONFIGURED`,
+        );
+
     // ─── Lambda: Investigation Trigger ────────────────────────────────────────
     // Triggers DevOps Agent investigation via HMAC-authenticated webhook
     const investigationTrigger = new lambda.Function(this, 'InvestigationTrigger', {
@@ -81,7 +111,8 @@ export class InvestigationWorkflow extends Construct {
       memorySize: 256,
       environment: {
         DEVOPS_AGENT_WEBHOOK_URL: props.devOpsAgentWebhookUrl,
-        WEBHOOK_SECRET_PARAM_NAME: props.webhookSecretParamName,
+        WEBHOOK_SECRET_ARN: devOpsAgentWebhookSecret.secretArn,
+        WEBHOOK_SECRET_REGION: props.devOpsAgentRegion,
         AGENT_SPACES_TABLE: props.agentSpacesTable.tableName,
       },
       logGroup: new logs.LogGroup(this, 'InvestigationTriggerLogs', {
@@ -96,15 +127,8 @@ export class InvestigationWorkflow extends Construct {
     // Grant read access to agent spaces routing table
     props.agentSpacesTable.grantReadData(investigationTrigger);
 
-    // Grant read access to the webhook secret in SSM Parameter Store
-    investigationTrigger.addToRolePolicy(new iam.PolicyStatement({
-      sid: 'ReadWebhookSecret',
-      effect: iam.Effect.ALLOW,
-      actions: ['ssm:GetParameter'],
-      resources: [
-        `arn:aws:ssm:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:parameter${props.webhookSecretParamName}`,
-      ],
-    }));
+    // Grant read access to the webhook secret in Secrets Manager
+    devOpsAgentWebhookSecret.grantRead(investigationTrigger);
 
     // Grant read access to the optional Jira routing config in SSM Parameter
     // Store. The trigger Lambda inlines these values into the prompt sent to

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/devops-agent-space-stack.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/devops-agent-space-stack.ts
@@ -1,0 +1,73 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { DevOpsAgentSpace } from './constructs/devops-agent-space';
+
+/**
+ * DevOpsAgentSpaceStack — owns the AWS DevOps Agent Agent Space and everything
+ * needed to use it: IAM roles, operator app, the AWS monitor association, and
+ * the eventChannel webhook (URL as output, HMAC secret in Secrets Manager).
+ *
+ * Deploys to the DevOps Agent region (`devOpsAgentRegion` context), which may
+ * differ from the main stack's region — an Agent Space monitors resources
+ * across all regions of the associated account, so it does not need to live
+ * with the rest of the infrastructure. All heavy lifting is in the reusable
+ * DevOpsAgentSpace construct (lib/constructs/devops-agent-space.ts).
+ *
+ * Replaces the imperative `aws devops-agent` CLI flow previously driven by
+ * scripts/setup-wizard.ts (Agent Space creation, IAM roles, account
+ * association, webhook, operator app) — including the manual retry-with-backoff
+ * loop the wizard used to work around IAM propagation delays.
+ */
+export interface DevOpsAgentSpaceStackProps extends cdk.StackProps {
+  projectName: string;
+  /** Deployment environment — drives log retention. See DevOpsAgentSpaceProps. */
+  deployEnvironment: string;
+}
+
+export class DevOpsAgentSpaceStack extends cdk.Stack {
+  public readonly agentSpaceId: string;
+  public readonly webhookUrl: string;
+
+  constructor(scope: Construct, id: string, props: DevOpsAgentSpaceStackProps) {
+    super(scope, id, props);
+
+    const space = new DevOpsAgentSpace(this, 'Space', {
+      name: props.projectName,
+      description: 'Agent Space for the Proactive Health Event Impact Analyzer',
+      deployEnvironment: props.deployEnvironment,
+    });
+
+    this.agentSpaceId = space.agentSpaceId;
+    this.webhookUrl = space.webhookUrl;
+
+    new cdk.CfnOutput(this, 'AgentSpaceId', {
+      description: 'DevOps Agent Agent Space ID',
+      value: space.agentSpaceId,
+    });
+
+    new cdk.CfnOutput(this, 'AgentSpaceArn', {
+      description: 'DevOps Agent Agent Space ARN',
+      value: space.agentSpaceArn,
+    });
+
+    new cdk.CfnOutput(this, 'WebhookUrl', {
+      description: 'Generic webhook URL for triggering investigations',
+      value: space.webhookUrl,
+    });
+
+    new cdk.CfnOutput(this, 'WebhookSecretArn', {
+      description: 'Secrets Manager ARN holding the webhook HMAC secret',
+      value: space.webhookSecret?.secretArn ?? '',
+    });
+
+    new cdk.CfnOutput(this, 'AgentSpaceRoleArn', {
+      description: 'Monitoring role assumed by DevOps Agent',
+      value: space.agentSpaceRole.roleArn,
+    });
+
+    new cdk.CfnOutput(this, 'OperatorRoleArn', {
+      description: 'Operator app (web console) role',
+      value: space.operatorRole.roleArn,
+    });
+  }
+}

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/health-event-analyzer-stack.ts
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/lib/health-event-analyzer-stack.ts
@@ -11,11 +11,28 @@ import { Notification } from './constructs/notification';
 export const VALID_ENVIRONMENTS = ['production', 'staging'] as const;
 export type Environment = typeof VALID_ENVIRONMENTS[number];
 
+export interface HealthEventAnalyzerStackProps extends cdk.StackProps {
+  /** DevOps Agent webhook URL, from the DevOpsAgentSpaceStack output (via CDK context). */
+  devOpsAgentWebhookUrl: string;
+  /**
+   * ARN of the Secrets Manager secret holding the webhook HMAC secret, from the
+   * DevOpsAgentSpaceStack output (via CDK context). Empty string on a bare
+   * synth/test before the Agent Space stack has ever been deployed.
+   */
+  devOpsAgentWebhookSecretArn: string;
+  /**
+   * Region hosting the DevOps Agent Agent Space. Defaults to this stack's own
+   * region when not supplied — an Agent Space monitors resources across ALL
+   * Regions of an associated account, so it need not sit in the deploy Region.
+   */
+  devOpsAgentRegion?: string;
+}
+
 export class HealthEventAnalyzerStack extends cdk.Stack {
   /** The resolved deployment environment (production or staging) for this stack */
   public readonly deployEnvironment: Environment;
 
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props: HealthEventAnalyzerStackProps) {
     super(scope, id, props);
 
     // Environment configuration
@@ -39,37 +56,27 @@ export class HealthEventAnalyzerStack extends cdk.Stack {
       default: '',
     });
 
-    const devOpsAgentWebhookUrl = new cdk.CfnParameter(this, 'DevOpsAgentWebhookUrl', {
-      type: 'String',
-      description: 'AWS DevOps Agent webhook URL for triggering investigations',
-    });
+    // DevOps Agent webhook URL and Secrets Manager ARN, sourced from the
+    // DevOpsAgentSpaceStack's outputs. These are CDK context values (resolved
+    // and passed by scripts/setup-wizard.ts via `--context` after reading the
+    // Agent Space stack's outputs with `aws cloudformation describe-stacks`),
+    // not CloudFormation parameters — the Agent Space stack itself is now
+    // CDK-managed, so there is no longer a manual value for an operator to
+    // paste in at deploy time.
+    const devOpsAgentWebhookUrl = props.devOpsAgentWebhookUrl;
+    const devOpsAgentWebhookSecretArn = props.devOpsAgentWebhookSecretArn;
 
     // Region hosting the DevOps Agent Agent Space. Defaults to this stack's region
-    // (same-region deployment); set it when the Agent Space lives elsewhere — the
+    // (same-region deployment); differs when the Agent Space lives elsewhere — the
     // service is only available in a subset of Regions, and an Agent Space monitors
     // resources across ALL Regions of an associated account, so it need not sit in
-    // the deploy Region. The setup wizard passes the value it resolved from
-    // DEVOPS_AGENT_REGION. See shared/README.md ("AWS DevOps Agent Region").
-    const devOpsAgentRegion = new cdk.CfnParameter(this, 'DevOpsAgentRegion', {
-      type: 'String',
-      description: 'Region hosting the DevOps Agent Agent Space (defaults to the stack region)',
-      default: '',
-    });
+    // the deploy Region. See shared/README.md ("AWS DevOps Agent Region").
+    const resolvedDevOpsAgentRegion = props.devOpsAgentRegion || this.region;
 
-    // Empty parameter means "same region as the stack".
-    const resolvedDevOpsAgentRegion = cdk.Fn.conditionIf(
-      new cdk.CfnCondition(this, 'HasDevOpsAgentRegion', {
-        expression: cdk.Fn.conditionNot(cdk.Fn.conditionEquals(devOpsAgentRegion.valueAsString, '')),
-      }).logicalId,
-      devOpsAgentRegion.valueAsString,
-      this.region,
-    ).toString();
-
-    // SSM Parameter Store paths for secrets (actual SecureString values are
-    // created externally by the setup wizard — CDK just references the paths
-    // in Lambda environment variables and grants read permissions)
+    // SSM Parameter Store paths for the Slack/MS Teams webhook secrets. These
+    // remain plain SSM SecureStrings set by the setup wizard — unrelated to the
+    // DevOps Agent webhook secret above, which now lives in Secrets Manager.
     const ssmParamPrefix = `/health-analyzer/${this.deployEnvironment}`;
-    const webhookSecretParamName = `${ssmParamPrefix}/webhook-secret`;
     const slackWebhookParamName = `${ssmParamPrefix}/slack-webhook-url`;
     const msTeamsWebhookParamName = `${ssmParamPrefix}/msteams-webhook-url`;
 
@@ -84,9 +91,9 @@ export class HealthEventAnalyzerStack extends cdk.Stack {
       notificationTopic: notification.topic,
       teamsTable: notification.teamsTable,
       agentSpacesTable: notification.agentSpacesTable,
-      devOpsAgentWebhookUrl: devOpsAgentWebhookUrl.valueAsString,
+      devOpsAgentWebhookUrl,
       devOpsAgentRegion: resolvedDevOpsAgentRegion,
-      webhookSecretParamName,
+      devOpsAgentWebhookSecretArn,
       slackWebhookParamName,
       msTeamsWebhookParamName,
       deployEnvironment: this.deployEnvironment,

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/package.json
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-devops-agent": "^3.1053.0",
+    "@aws-sdk/client-secrets-manager": "^3.1053.0",
     "aws-cdk-lib": "^2.246.0",
     "cdk-nag": "^2.38.2",
     "constructs": "^10.3.0",

--- a/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/scripts/bundle-lambdas.js
+++ b/observability/proactive-health-event-impact-analyzer/infrastructure/cdk/scripts/bundle-lambdas.js
@@ -61,6 +61,15 @@ const FUNCTIONS = [
     name: 'investigation-callback',
     external: ['@aws-sdk/client-dynamodb', '@aws-sdk/client-sfn'],
   },
+  {
+    // Backs the CfnCustomResource in lib/constructs/devops-agent-space.ts.
+    // Neither @aws-sdk/client-devops-agent (too new for the bundled runtime
+    // SDK) nor @aws-sdk/client-secrets-manager is marked external here, so
+    // both are bundled in full — no assumption is made about what the
+    // Lambda Node.js 24 runtime's SDK snapshot happens to include.
+    name: 'devops-agent-webhook-provisioner',
+    external: [],
+  },
 ];
 
 /** Matches the Node.js 24 Lambda runtime configured on every function. */

--- a/observability/proactive-health-event-impact-analyzer/scripts/cleanup.ts
+++ b/observability/proactive-health-event-impact-analyzer/scripts/cleanup.ts
@@ -107,15 +107,29 @@ const JIRA_SSM_PARAMS = [
   SSM_PARAM_JIRA_SITE_URL,
 ];
 
-// SSM SecureString parameters for secrets (created by setup wizard)
+// SSM SecureString parameters for the Slack/MS Teams webhook secrets (created
+// by the setup wizard). The DevOps Agent webhook secret is no longer among
+// these — it now lives in a CDK-managed Secrets Manager secret (RemovalPolicy
+// DESTROY), which `cdk destroy` on the Agent Space stack removes automatically.
 const SECRET_SSM_PARAMS = [
-  '/health-analyzer/production/webhook-secret',
   '/health-analyzer/production/slack-webhook-url',
   '/health-analyzer/production/msteams-webhook-url',
-  '/health-analyzer/staging/webhook-secret',
   '/health-analyzer/staging/slack-webhook-url',
   '/health-analyzer/staging/msteams-webhook-url',
 ];
+
+/**
+ * Resolves the Agent Space region, mirroring scripts/setup-wizard.ts's
+ * resolveAgentRegion(): DEVOPS_AGENT_REGION overrides, otherwise same as the
+ * deploy region. Destroying HealthEventAnalyzerAgentSpace-<region> requires
+ * this to match whatever region it was actually deployed to, since `cdk
+ * destroy` re-synthesizes the app to resolve stack names before deleting.
+ */
+function resolveAgentRegion(deployRegion: string): string {
+  const override = process.env.DEVOPS_AGENT_REGION;
+  if (override && override.trim()) return override.trim();
+  return deployRegion;
+}
 
 // ─── Main ───────────────────────────────────────────────────────────────────
 
@@ -142,10 +156,14 @@ async function main(): Promise<void> {
   // Select region
   const regionIdx = await askChoice('Which region do you want to clean up?', SUPPORTED_REGIONS);
   const region = SUPPORTED_REGIONS[regionIdx];
+  const agentRegion = resolveAgentRegion(region);
   info(`Region: ${region}`);
+  if (agentRegion !== region) {
+    info(`Agent Space region: ${agentRegion} (from DEVOPS_AGENT_REGION)`);
+  }
 
   const confirmAll = await askYesNo(
-    `\n  Are you sure you want to delete ALL resources in ${region} for account ${accountId}?`
+    `\n  Are you sure you want to delete ALL resources in ${region}${agentRegion !== region ? ` and ${agentRegion}` : ''} for account ${accountId}?`
   );
   if (!confirmAll) {
     console.log('\n  Cleanup cancelled.');
@@ -153,11 +171,19 @@ async function main(): Promise<void> {
     return;
   }
 
-  // ─── Step 1: Destroy CDK Stack ──────────────────────────────────────────
-  console.log('\n┌─ Step 1: CDK Stack');
+  // ─── Step 1: Destroy CDK Stacks ─────────────────────────────────────────
+  // The DevOps Agent Space, its IAM roles, the AWS account association, the
+  // operator app, and the eventChannel webhook (including its Secrets
+  // Manager secret) are all now CDK-managed — destroying
+  // HealthEventAnalyzerAgentSpace-<agentRegion> tears them all down, replacing
+  // what used to be separate imperative "delete Agent Space" / "deregister
+  // service" / "delete IAM roles" steps here.
+  console.log('\n┌─ Step 1: CDK Stacks');
   console.log('└' + '─'.repeat(55));
 
   const stackName = `HealthEventAnalyzerStack-${region}`;
+  const agentSpaceStackName = `HealthEventAnalyzerAgentSpace-${agentRegion}`;
+  const cdkDir = path.resolve(__dirname, '../infrastructure/cdk');
 
   try {
     exec(`aws cloudformation describe-stacks --stack-name ${stackName} --region ${region} --no-cli-pager`, true);
@@ -165,11 +191,10 @@ async function main(): Promise<void> {
 
     const destroyStack = await askYesNo(`  Destroy CDK stack ${stackName}?`);
     if (destroyStack) {
-      info('Destroying CDK stack (this may take a few minutes)...');
-      const cdkDir = path.resolve(__dirname, '../infrastructure/cdk');
+      info('Destroying main CDK stack (this may take a few minutes)...');
       try {
         execSync(
-          `npx cdk destroy --all --force`,
+          `npx cdk destroy ${stackName} -c devOpsAgentRegion=${agentRegion} --force`,
           { cwd: cdkDir, encoding: 'utf-8', stdio: 'inherit', env: { ...process.env, AWS_REGION: region, AWS_DEFAULT_REGION: region } }
         );
         success(`Stack destroyed: ${stackName}`);
@@ -177,149 +202,47 @@ async function main(): Promise<void> {
         warn('CDK destroy had issues. You may need to delete the stack manually from CloudFormation console.');
       }
     } else {
-      skipped('CDK stack preserved');
+      skipped('Main CDK stack preserved');
     }
   } catch {
     info(`Stack ${stackName} not found — nothing to destroy`);
   }
 
-  // ─── Step 2: Delete DevOps Agent Space ──────────────────────────────────
-  console.log('\n┌─ Step 2: DevOps Agent Space');
-  console.log('└' + '─'.repeat(55));
-
   try {
-    const spaces = execJson(
-      `aws devops-agent list-agent-spaces --region ${region} --no-cli-pager`
+    exec(`aws cloudformation describe-stacks --stack-name ${agentSpaceStackName} --region ${agentRegion} --no-cli-pager`, true);
+    info(`Found stack: ${agentSpaceStackName}`);
+
+    const destroySpaceStack = await askYesNo(
+      `  ⚠️  Destroy DevOps Agent Space stack ${agentSpaceStackName}? This deletes the Agent Space and ALL its associations, webhooks, and investigations.`
     );
-
-    if (spaces.agentSpaces && spaces.agentSpaces.length > 0) {
-      const spaceOptions = spaces.agentSpaces.map(
-        (s: any) => `${s.name} (${s.agentSpaceId})`
-      );
-      spaceOptions.push('Skip — do not delete any space');
-
-      const spaceIdx = await askChoice('Which Agent Space do you want to delete?', spaceOptions);
-
-      if (spaceIdx < spaces.agentSpaces.length) {
-        const spaceId = spaces.agentSpaces[spaceIdx].agentSpaceId;
-        const spaceName = spaces.agentSpaces[spaceIdx].name;
-
-        const confirmSpace = await askYesNo(
-          `  ⚠️  Delete Agent Space "${spaceName}" and ALL its associations, webhooks, investigations?`
+    if (destroySpaceStack) {
+      info('Destroying DevOps Agent Space stack (this may take a few minutes)...');
+      try {
+        // -c devOpsAgentRegion must match the value used at deploy time so CDK
+        // resolves the same stack ID (HealthEventAnalyzerAgentSpace-<agentRegion>).
+        execSync(
+          `npx cdk destroy ${agentSpaceStackName} -c devOpsAgentRegion=${agentRegion} --force`,
+          { cwd: cdkDir, encoding: 'utf-8', stdio: 'inherit', env: { ...process.env, AWS_REGION: agentRegion, AWS_DEFAULT_REGION: agentRegion } }
         );
-
-        if (confirmSpace) {
-          // First, disassociate all services
-          info('Removing associations...');
-          try {
-            const associations = execJson(
-              `aws devops-agent list-associations --agent-space-id ${spaceId} --region ${region} --no-cli-pager`
-            );
-            for (const assoc of associations.associations || []) {
-              try {
-                exec(
-                  `aws devops-agent disassociate-service --agent-space-id ${spaceId} --association-id ${assoc.associationId} --region ${region} --no-cli-pager`,
-                  true
-                );
-                success(`Disassociated: ${assoc.serviceId} (${assoc.associationId})`);
-              } catch {
-                warn(`Failed to disassociate ${assoc.associationId}`);
-              }
-            }
-          } catch {
-            // No associations
-          }
-
-          // Disable operator app
-          info('Disabling operator app...');
-          try {
-            exec(
-              `aws devops-agent disable-operator-app --agent-space-id ${spaceId} --region ${region} --no-cli-pager`,
-              true
-            );
-            success('Operator app disabled');
-          } catch {
-            // Already disabled or doesn't exist
-          }
-
-          // Delete the space
-          info('Deleting Agent Space...');
-          try {
-            exec(
-              `aws devops-agent delete-agent-space --agent-space-id ${spaceId} --region ${region} --no-cli-pager`,
-              true
-            );
-            success(`Agent Space deleted: ${spaceName}`);
-          } catch (error: any) {
-            warn(`Failed to delete Agent Space. You may need to delete it from the console.`);
-          }
-        } else {
-          skipped('Agent Space preserved');
-        }
-      } else {
-        skipped('No Agent Space deleted');
+        success(`Stack destroyed: ${agentSpaceStackName}`);
+      } catch {
+        warn('CDK destroy had issues. You may need to delete the stack manually from CloudFormation console.');
       }
     } else {
-      info('No Agent Spaces found in this region');
+      skipped('DevOps Agent Space stack preserved');
     }
   } catch {
-    info('Could not list Agent Spaces');
+    info(`Stack ${agentSpaceStackName} not found — nothing to destroy`);
   }
 
-  // ─── Step 3: Deregister eventChannel service ────────────────────────────
-  console.log('\n┌─ Step 3: Registered Services');
-  console.log('└' + '─'.repeat(55));
-
-  try {
-    const services = execJson(
-      `aws devops-agent list-services --region ${region} --no-cli-pager`
-    );
-
-    if (services.services && services.services.length > 0) {
-      const deleteServices = await askYesNo('  Delete registered DevOps Agent services (eventChannel, etc.)?');
-      if (deleteServices) {
-        for (const svc of services.services) {
-          try {
-            exec(
-              `aws devops-agent deregister-service --service-id ${svc.serviceId} --region ${region} --no-cli-pager`,
-              true
-            );
-            success(`Deregistered service: ${svc.serviceType || svc.serviceId}`);
-          } catch {
-            warn(`Failed to deregister service ${svc.serviceId}`);
-          }
-        }
-      } else {
-        skipped('Services preserved');
-      }
-    } else {
-      info('No registered services found');
-    }
-  } catch {
-    info('Could not list services');
-  }
-
-  // ─── Step 4: Delete IAM Roles ───────────────────────────────────────────
-  console.log('\n┌─ Step 4: IAM Roles');
-  console.log('└' + '─'.repeat(55));
-
-  const deleteRoles = await askYesNo('  Delete DevOps Agent IAM roles?');
-  if (deleteRoles) {
-    await deleteIamRole('DevOpsAgentRole-AgentSpace');
-    await deleteIamRole('DevOpsAgentRole-WebappAdmin');
-  } else {
-    skipped('IAM roles preserved');
-  }
-
-  // ─── Step 5: Jira routing config (SSM Parameter Store) ──────────────────
-  console.log('\n┌─ Step 5: Jira routing config (SSM Parameter Store)');
+  // ─── Step 2: Jira routing config (SSM Parameter Store) ──────────────────
+  console.log('\n┌─ Step 2: Jira routing config (SSM Parameter Store)');
   console.log('└' + '─'.repeat(55));
 
   await deleteJiraSsmParams(region);
-  await removeJiraSsmReadGrant();
 
-  // ─── Step 6: Secret SSM Parameters ──────────────────────────────────────
-  console.log('\n┌─ Step 6: Secret SSM Parameters');
+  // ─── Step 3: Slack/MS Teams Secret SSM Parameters ───────────────────────
+  console.log('\n┌─ Step 3: Slack/MS Teams Secret SSM Parameters');
   console.log('└' + '─'.repeat(55));
 
   await deleteSsmParams(region, SECRET_SSM_PARAMS, 'secret');
@@ -367,69 +290,12 @@ async function deleteSsmParams(region: string, params: string[], label: string):
   }
 }
 
-async function removeJiraSsmReadGrant(): Promise<void> {
-  const roleName = 'DevOpsAgentRole-AgentSpace';
-  const policyName = 'AllowReadHealthAnalyzerJiraSsmParams';
-  let exists = false;
-  try {
-    exec(
-      `aws iam get-role-policy --role-name ${roleName} --policy-name ${policyName} --no-cli-pager`,
-      true
-    );
-    exists = true;
-  } catch {
-    // not present, nothing to clean up
-  }
-  if (!exists) return;
-  try {
-    exec(
-      `aws iam delete-role-policy --role-name ${roleName} --policy-name ${policyName} --no-cli-pager`,
-      true
-    );
-    success(`Removed inline policy: ${policyName} from ${roleName}`);
-  } catch {
-    warn(`Failed to remove inline policy ${policyName} from ${roleName} — delete manually if needed.`);
-  }
-}
-
-async function deleteIamRole(roleName: string): Promise<void> {
-  try {
-    exec(`aws iam get-role --role-name ${roleName} --no-cli-pager`, true);
-  } catch {
-    info(`Role ${roleName} does not exist — skipping`);
-    return;
-  }
-
-  try {
-    // Detach managed policies
-    const policies = execJson(
-      `aws iam list-attached-role-policies --role-name ${roleName} --no-cli-pager`
-    );
-    for (const policy of policies.AttachedPolicies || []) {
-      exec(
-        `aws iam detach-role-policy --role-name ${roleName} --policy-arn ${policy.PolicyArn} --no-cli-pager`,
-        true
-      );
-    }
-
-    // Delete inline policies
-    const inlinePolicies = execJson(
-      `aws iam list-role-policies --role-name ${roleName} --no-cli-pager`
-    );
-    for (const policyName of inlinePolicies.PolicyNames || []) {
-      exec(
-        `aws iam delete-role-policy --role-name ${roleName} --policy-name ${policyName} --no-cli-pager`,
-        true
-      );
-    }
-
-    // Delete the role
-    exec(`aws iam delete-role --role-name ${roleName} --no-cli-pager`, true);
-    success(`Deleted role: ${roleName}`);
-  } catch {
-    warn(`Failed to delete role ${roleName}. It may have dependencies.`);
-  }
-}
+// removeJiraSsmReadGrant() and deleteIamRole() (for DevOpsAgentRole-AgentSpace
+// / DevOpsAgentRole-WebappAdmin) used to live here. Both are gone now: the
+// IAM roles are CDK-managed under different, project-prefixed names
+// (health-event-analyzer-AgentSpaceRole / -OperatorRole — see
+// infrastructure/cdk/lib/constructs/devops-agent-space.ts) and are deleted
+// automatically when HealthEventAnalyzerAgentSpace-<region> is destroyed above.
 
 // ─── Entry Point ────────────────────────────────────────────────────────────
 

--- a/observability/proactive-health-event-impact-analyzer/scripts/setup-wizard.ts
+++ b/observability/proactive-health-event-impact-analyzer/scripts/setup-wizard.ts
@@ -3,13 +3,16 @@
  * Setup Wizard — Proactive Health Event Impact Analyzer
  *
  * Interactive guided deployment that:
- * 1. Checks prerequisites (AWS CLI, CDK, credentials)
- * 2. Creates IAM roles for DevOps Agent (if needed)
- * 3. Creates or selects a DevOps Agent Space
- * 4. Associates the AWS account for topology discovery
- * 5. Creates or selects a webhook (eventChannel)
- * 6. Enables the operator app
- * 7. Deploys the CDK stack with all parameters
+ * 1. Resolves the target AWS region (and Agent Space region, if split)
+ * 2. Checks prerequisites (AWS CLI, CDK, credentials)
+ * 3. Collects optional notification channel settings (email, Slack, MS Teams)
+ * 4. Deploys DevOpsAgentSpaceStack (Agent Space, IAM roles, operator app, AWS
+ *    account association, and the eventChannel webhook — all via CDK L1
+ *    constructs, see infrastructure/cdk/lib/constructs/devops-agent-space.ts),
+ *    then deploys the main stack with that stack's outputs threaded through
+ *    as CDK context
+ * 5. (Optional) Registers the Atlassian Jira MCP server and associates it
+ *    with the now-deployed Agent Space
  *
  * Usage: npx ts-node scripts/setup-wizard.ts
  */
@@ -220,12 +223,19 @@ interface SetupState {
    */
   agentRegion: string;
   accountId: string;
+  /** Agent Space name/ID — now created by DevOpsAgentSpaceStack (CDK-managed), read back after that stack deploys. */
   agentSpaceId: string;
   agentSpaceName: string;
-  associationId: string;
+  /** Generic webhook URL, read back from DevOpsAgentSpaceStack's WebhookUrl output. */
   webhookUrl: string;
-  webhookSecret: string;
-  operatorAppEnabled: boolean;
+  /**
+   * ARN of the Secrets Manager secret holding the webhook HMAC secret, read
+   * back from DevOpsAgentSpaceStack's WebhookSecretArn output. The wizard
+   * never sees the secret value itself — the custom resource inside that
+   * stack writes it directly to Secrets Manager (see
+   * infrastructure/cdk/lib/constructs/devops-agent-space.ts).
+   */
+  webhookSecretArn: string;
   notificationEmail: string;
   slackWebhookUrl: string;
   msTeamsWebhookUrl: string;
@@ -449,10 +459,8 @@ async function main(): Promise<void> {
     accountId: '',
     agentSpaceId: '',
     agentSpaceName: '',
-    associationId: '',
     webhookUrl: '',
-    webhookSecret: '',
-    operatorAppEnabled: false,
+    webhookSecretArn: '',
     notificationEmail: '',
     slackWebhookUrl: '',
     msTeamsWebhookUrl: '',
@@ -553,98 +561,13 @@ async function main(): Promise<void> {
     return;
   }
 
-  // ─── Step 2: DevOps Agent Space ─────────────────────────────────────────
-  step(2, 'DevOps Agent Space');
-
-  const spaceOk = await runStep('DevOps Agent Space', async () => {
-    const existingSpaces = execJson(
-      `aws devops-agent list-agent-spaces --region ${state.agentRegion} --no-cli-pager`
-    );
-
-    if (existingSpaces.agentSpaces && existingSpaces.agentSpaces.length > 0) {
-      const useExisting = await askYesNo(
-        `Found ${existingSpaces.agentSpaces.length} existing Agent Space(s). Use one of them?`
-      );
-
-      if (useExisting) {
-        const spaceOptions = existingSpaces.agentSpaces.map(
-          (s: any) => `${s.name} (${s.agentSpaceId})`
-        );
-        const spaceIdx = await askChoice('Select an Agent Space:', spaceOptions);
-        state.agentSpaceId = existingSpaces.agentSpaces[spaceIdx].agentSpaceId;
-        state.agentSpaceName = existingSpaces.agentSpaces[spaceIdx].name;
-        success(`Using existing space: ${state.agentSpaceName}`);
-      } else {
-        await createAgentSpace(state);
-      }
-    } else {
-      info('No existing Agent Spaces found. Creating a new one...');
-      await createAgentSpace(state);
-    }
-  });
-
-  if (!spaceOk && stepResults[stepResults.length - 1]?.status === 'failed') {
-    aborted = true;
-    displayCompletionSummary();
-    rl.close();
-    return;
-  }
-
-  // ─── Step 3: IAM Roles ──────────────────────────────────────────────────
-  step(3, 'IAM Roles for DevOps Agent');
-
-  const iamOk = await runStep('IAM Roles', async () => {
-    await ensureIamRoles(state);
-  });
-  if (!iamOk && stepResults[stepResults.length - 1]?.status === 'failed') {
-    aborted = true;
-    displayCompletionSummary();
-    rl.close();
-    return;
-  }
-
-  // ─── Step 4: AWS Account Association ────────────────────────────────────
-  step(4, 'AWS Account Association (topology discovery)');
-
-  const assocOk = await runStep('Account Association', async () => {
-    await ensureAccountAssociation(state);
-  });
-  if (!assocOk && stepResults[stepResults.length - 1]?.status === 'failed') {
-    aborted = true;
-    displayCompletionSummary();
-    rl.close();
-    return;
-  }
-
-  // ─── Step 5: Webhook ────────────────────────────────────────────────────
-  step(5, 'Webhook Configuration');
-
-  const webhookOk = await runStep('Webhook Configuration', async () => {
-    await ensureWebhook(state);
-  });
-  if (!webhookOk && stepResults[stepResults.length - 1]?.status === 'failed') {
-    aborted = true;
-    displayCompletionSummary();
-    rl.close();
-    return;
-  }
-
-  // ─── Step 6: Operator App ───────────────────────────────────────────────
-  step(6, 'Operator App');
-
-  await runStep('Operator App', async () => {
-    await ensureOperatorApp(state);
-  });
-
-  // ─── Step 7: Atlassian Jira (optional) ──────────────────────────────────
-  step(7, 'Atlassian Jira integration (optional)');
-
-  await runStep('Jira Integration', async () => {
-    await ensureJiraMcp(state, args.jiraTools);
-  });
-
-  // ─── Step 8: Notification Channels (optional) ───────────────────────────
-  step(8, 'Notification Channels (optional)');
+  // ─── Step 2: Notification Channels (optional) ───────────────────────────
+  // Collected before the deploy since these are plain prompts with no AWS
+  // dependency — unlike the DevOps Agent Space, IAM roles, account
+  // association, operator app, and webhook, which used to be separate manual
+  // steps here but are now provisioned entirely by CDK (DevOpsAgentSpaceStack,
+  // deployed as part of Step 3 below).
+  step(2, 'Notification Channels (optional)');
 
   const wantEmail = await askYesNo('Configure email notifications?', false);
   if (wantEmail) {
@@ -662,8 +585,12 @@ async function main(): Promise<void> {
   }
   recordStep('Notification Channels', 'succeeded');
 
-  // ─── Step 9: CDK Bootstrap & Deploy ─────────────────────────────────────
-  step(9, 'CDK Deployment');
+  // ─── Step 3: CDK Bootstrap & Deploy ─────────────────────────────────────
+  // Deploys DevOpsAgentSpaceStack (Agent Space, IAM roles, operator app, AWS
+  // account association, and the eventChannel webhook — see
+  // infrastructure/cdk/lib/constructs/devops-agent-space.ts) and then the main
+  // stack, wiring the Agent Space stack's outputs through as CDK context.
+  step(3, 'CDK Deployment (DevOps Agent Space + main stack)');
 
   console.log('\n  Configuration summary:');
   console.log(`    Region:          ${state.region}`);
@@ -671,30 +598,39 @@ async function main(): Promise<void> {
     console.log(`    Agent Space rgn: ${state.agentRegion}`);
   }
   console.log(`    Account:         ${state.accountId}`);
-  console.log(`    Agent Space:     ${state.agentSpaceName} (${state.agentSpaceId})`);
-  console.log(`    Webhook URL:     ${state.webhookUrl ? state.webhookUrl.substring(0, 60) + '...' : '(not set)'}`);
   console.log(`    Email:           ${state.notificationEmail || '(none)'}`);
   console.log(`    Slack:           ${state.slackWebhookUrl ? 'configured' : '(none)'}`);
   console.log(`    MS Teams:        ${state.msTeamsWebhookUrl ? 'configured' : '(none)'}`);
-  console.log(
-    `    Jira:            ${
-      state.jiraEnabled
-        ? `${state.jiraSiteUrl} → ${state.jiraProjectKey} (${state.jiraIssueType})`
-        : '(none)'
-    }`
-  );
+  console.log('');
+  info('The DevOps Agent Space, IAM roles, account association, operator app,');
+  info('and webhook are provisioned by CDK below — no manual AWS CLI steps.');
 
   const proceed = await askYesNo('\n  Proceed with deployment?');
   if (!proceed) {
-    console.log('\n  Deployment cancelled. Your DevOps Agent setup is preserved.');
+    console.log('\n  Deployment cancelled.');
     recordStep('CDK Deployment', 'skipped', 'User cancelled');
     displayCompletionSummary();
     rl.close();
     return;
   }
 
-  await runStep('CDK Deployment', async () => {
+  const deployOk = await runStep('CDK Deployment', async () => {
     await deployCdk(state);
+  });
+  if (!deployOk && stepResults[stepResults.length - 1]?.status === 'failed') {
+    aborted = true;
+    displayCompletionSummary();
+    rl.close();
+    return;
+  }
+
+  // ─── Step 4: Atlassian Jira (optional) ───────────────────────────────────
+  // Runs after the deploy above: the Agent Space (state.agentSpaceId) only
+  // exists once DevOpsAgentSpaceStack has actually been deployed.
+  step(4, 'Atlassian Jira integration (optional)');
+
+  await runStep('Jira Integration', async () => {
+    await ensureJiraMcp(state, args.jiraTools);
   });
 
   // ─── Done ───────────────────────────────────────────────────────────────
@@ -786,10 +722,8 @@ async function runJiraOnly(args: CliOptions): Promise<void> {
     accountId: '',
     agentSpaceId: '',
     agentSpaceName: '',
-    associationId: '',
     webhookUrl: '',
-    webhookSecret: '',
-    operatorAppEnabled: false,
+    webhookSecretArn: '',
     notificationEmail: '',
     slackWebhookUrl: '',
     msTeamsWebhookUrl: '',
@@ -898,394 +832,15 @@ async function pickExistingAgentSpace(state: SetupState, preselectedId?: string)
   success(`Using Agent Space: ${state.agentSpaceName}`);
 }
 
-async function createAgentSpace(state: SetupState): Promise<void> {
-  const name = await ask('  Agent Space name [health-event-analyzer]: ') || 'health-event-analyzer';
-  const description = await ask('  Description [Health Event Impact Analyzer]: ') || 'Health Event Impact Analyzer';
-
-  info('Creating Agent Space...');
-  const result = execJson(
-    `aws devops-agent create-agent-space --name "${name}" --description "${description}" --region ${state.agentRegion} --no-cli-pager`
-  );
-
-  state.agentSpaceId = result.agentSpace.agentSpaceId;
-  state.agentSpaceName = result.agentSpace.name;
-  success(`Agent Space created: ${state.agentSpaceName} (${state.agentSpaceId})`);
-}
-
-async function ensureIamRoles(state: SetupState): Promise<void> {
-  // Trust policies are region-scoped via the aws:SourceArn condition
-  // (arn:aws:aidevops:<region>:...:agentspace/*). If a role was created in a
-  // previous run for a DIFFERENT region than the one now selected, reusing it
-  // as-is makes associate-service fail with "Invalid STS role configuration ...
-  // Verify the role's trust policy" — because the assuming agent space's ARN
-  // (in the current region) doesn't match the stale condition. So we always
-  // (re)apply the trust policy for the current region: create-role when the
-  // role is missing, update-assume-role-policy when it already exists. This is
-  // idempotent and self-heals a region change across runs.
-  const spaceTrust = {
-    Version: '2012-10-17',
-    Statement: [{
-      Effect: 'Allow',
-      Principal: { Service: 'aidevops.amazonaws.com' },
-      Action: 'sts:AssumeRole',
-      Condition: {
-        StringEquals: { 'aws:SourceAccount': state.accountId },
-        ArnLike: { 'aws:SourceArn': `arn:aws:aidevops:${state.agentRegion}:${state.accountId}:agentspace/*` },
-      },
-    }],
-  };
-  const webappTrust = {
-    Version: '2012-10-17',
-    Statement: [{
-      Effect: 'Allow',
-      Principal: { Service: 'aidevops.amazonaws.com' },
-      Action: ['sts:AssumeRole', 'sts:TagSession'],
-      Condition: {
-        StringEquals: { 'aws:SourceAccount': state.accountId },
-        ArnLike: { 'aws:SourceArn': `arn:aws:aidevops:${state.agentRegion}:${state.accountId}:agentspace/*` },
-      },
-    }],
-  };
-
-  const spaceRoleExists = checkRoleExists('DevOpsAgentRole-AgentSpace');
-  const webappRoleExists = checkRoleExists('DevOpsAgentRole-WebappAdmin');
-
-  // ─── AgentSpace role ──────────────────────────────────────────────────────
-  const spaceTrustFile = writeTempJson('space-trust', spaceTrust);
-  try {
-    if (spaceRoleExists) {
-      exec(
-        `aws iam update-assume-role-policy --role-name DevOpsAgentRole-AgentSpace --policy-document file://${spaceTrustFile} --no-cli-pager`,
-        true
-      );
-      success(`Updated trust policy: DevOpsAgentRole-AgentSpace (region ${state.agentRegion})`);
-    } else {
-      info('Creating IAM role: DevOpsAgentRole-AgentSpace...');
-      exec(
-        `aws iam create-role --role-name DevOpsAgentRole-AgentSpace --assume-role-policy-document file://${spaceTrustFile} --no-cli-pager`,
-        true
-      );
-      success('Created role: DevOpsAgentRole-AgentSpace');
-    }
-  } finally {
-    tryUnlink(spaceTrustFile);
-  }
-
-  // Attach managed + inline policies (idempotent — safe to re-run)
-  exec(
-    'aws iam attach-role-policy --role-name DevOpsAgentRole-AgentSpace --policy-arn arn:aws:iam::aws:policy/AIDevOpsAgentAccessPolicy --no-cli-pager',
-    true
-  );
-  const additionalPolicyFile = writeTempJson('space-slr-policy', {
-    Version: '2012-10-17',
-    Statement: [{
-      Sid: 'AllowCreateServiceLinkedRoles',
-      Effect: 'Allow',
-      Action: ['iam:CreateServiceLinkedRole'],
-      Resource: [`arn:aws:iam::${state.accountId}:role/aws-service-role/resource-explorer-2.amazonaws.com/AWSServiceRoleForResourceExplorer`],
-    }],
-  });
-  try {
-    exec(
-      `aws iam put-role-policy --role-name DevOpsAgentRole-AgentSpace --policy-name AllowCreateServiceLinkedRoles --policy-document file://${additionalPolicyFile} --no-cli-pager`,
-      true
-    );
-  } finally {
-    tryUnlink(additionalPolicyFile);
-  }
-
-  // ─── WebappAdmin role ─────────────────────────────────────────────────────
-  const webappTrustFile = writeTempJson('webapp-trust', webappTrust);
-  try {
-    if (webappRoleExists) {
-      exec(
-        `aws iam update-assume-role-policy --role-name DevOpsAgentRole-WebappAdmin --policy-document file://${webappTrustFile} --no-cli-pager`,
-        true
-      );
-      success(`Updated trust policy: DevOpsAgentRole-WebappAdmin (region ${state.agentRegion})`);
-    } else {
-      info('Creating IAM role: DevOpsAgentRole-WebappAdmin...');
-      exec(
-        `aws iam create-role --role-name DevOpsAgentRole-WebappAdmin --assume-role-policy-document file://${webappTrustFile} --no-cli-pager`,
-        true
-      );
-      success('Created role: DevOpsAgentRole-WebappAdmin');
-    }
-  } finally {
-    tryUnlink(webappTrustFile);
-  }
-
-  exec(
-    'aws iam attach-role-policy --role-name DevOpsAgentRole-WebappAdmin --policy-arn arn:aws:iam::aws:policy/AIDevOpsOperatorAppAccessPolicy --no-cli-pager',
-    true
-  );
-
-  // Wait for IAM propagation (create AND update both need time to reach STS)
-  info('Waiting for IAM role propagation (10s)...');
-  await new Promise((resolve) => setTimeout(resolve, 10000));
-}
-
-function checkRoleExists(roleName: string): boolean {
-  try {
-    exec(`aws iam get-role --role-name ${roleName} --no-cli-pager`, true);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function ensureAccountAssociation(state: SetupState): Promise<void> {
-  // Check existing associations
-  const associations = execJson(
-    `aws devops-agent list-associations --agent-space-id ${state.agentSpaceId} --region ${state.agentRegion} --no-cli-pager`
-  );
-
-  const awsAssociation = associations.associations?.find(
-    (a: any) => a.configuration?.aws?.accountId === state.accountId
-  );
-
-  if (awsAssociation) {
-    state.associationId = awsAssociation.associationId;
-    success(`Account ${state.accountId} already associated (${state.associationId})`);
-    return;
-  }
-
-  info(`Associating account ${state.accountId} for topology discovery...`);
-
-  const configFile = writeTempJson('assoc-config', {
-    aws: {
-      assumableRoleArn: `arn:aws:iam::${state.accountId}:role/DevOpsAgentRole-AgentSpace`,
-      accountId: state.accountId,
-      accountType: 'monitor',
-    },
-  });
-
-  let result: any;
-  try {
-    // associate-service assumes DevOpsAgentRole-AgentSpace. IAM role/trust-policy
-    // changes are eventually consistent, so a freshly created (or just-updated)
-    // role can still fail STS assume-role with "Invalid STS role configuration ...
-    // Verify the role's trust policy" for a short window after creation. Retry
-    // with backoff so the step succeeds once propagation completes instead of
-    // forcing the user to manually retry.
-    const maxAttempts = 6;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        result = execJson(
-          `aws devops-agent associate-service --agent-space-id ${state.agentSpaceId} --service-id aws --configuration file://${configFile} --region ${state.agentRegion} --no-cli-pager`
-        );
-        break;
-      } catch (err: any) {
-        const msg = String(err?.stderr || err?.message || err);
-        const isTransientTrust =
-          /Invalid STS role configuration/i.test(msg) ||
-          /Verify the role's trust policy/i.test(msg);
-        if (!isTransientTrust || attempt === maxAttempts) {
-          throw err;
-        }
-        const delaySec = attempt * 10; // 10s, 20s, 30s, ...
-        warn(`Association not ready yet (IAM propagation). Retrying in ${delaySec}s (attempt ${attempt}/${maxAttempts - 1})...`);
-        await new Promise((resolve) => setTimeout(resolve, delaySec * 1000));
-      }
-    }
-  } finally {
-    tryUnlink(configFile);
-  }
-
-  state.associationId = result.association.associationId;
-  success(`Account associated: ${state.associationId} (status: ${result.association.status})`);
-}
-
-async function ensureWebhook(state: SetupState): Promise<void> {
-  // Check existing associations for eventChannel webhooks
-  const associations = execJson(
-    `aws devops-agent list-associations --agent-space-id ${state.agentSpaceId} --region ${state.agentRegion} --no-cli-pager`
-  );
-
-  // Look for existing eventChannel associations and their webhooks
-  const eventChannelAssociations = associations.associations?.filter(
-    (a: any) => a.configuration?.eventChannel !== undefined
-  ) || [];
-
-  if (eventChannelAssociations.length > 0) {
-    // The DevOps Agent service allows only ONE eventChannel association per
-    // AgentSpace. We must either reuse it or rotate it (disassociate + recreate).
-    const assoc = eventChannelAssociations[0];
-
-    let existingUrl: string | undefined;
-    try {
-      const webhooks = execJson(
-        `aws devops-agent list-webhooks --agent-space-id ${state.agentSpaceId} --association-id ${assoc.associationId} --region ${state.agentRegion} --no-cli-pager`
-      );
-      existingUrl = webhooks.webhooks?.[0]?.webhookUrl;
-    } catch {
-      // list-webhooks failed; treat as no usable webhook found.
-    }
-
-    if (existingUrl) {
-      info(`Found existing eventChannel webhook: ${existingUrl.substring(0, 60)}...`);
-
-      const choices = [
-        'Reuse the existing webhook (I have or can recover the HMAC secret)',
-        'Rotate it: delete this association and create a fresh one (new URL + new secret)',
-      ];
-      const choice = await askChoice('How do you want to proceed?', choices);
-
-      if (choice === 0) {
-        state.webhookUrl = existingUrl;
-        const recovered = tryRecoverSecretFromDeployedStack(state);
-        if (recovered) {
-          state.webhookSecret = recovered;
-          success('Recovered HMAC secret from a previously deployed stack.');
-          return;
-        }
-
-        warn('AWS does not expose the HMAC secret after creation. It is only returned once');
-        warn('by associate-service. Look in any of these places for the previous value:');
-        console.log('    • The DEVOPS_AGENT_WEBHOOK_SECRET env var on the InvestigationTrigger Lambda');
-        console.log('    • The CloudFormation parameter DevOpsAgentWebhookSecret on a previous deployment');
-        console.log('    • Wherever you stored it during the prior setup (password manager / SSM / etc.)');
-        console.log('  If it is truly lost, re-run this wizard and choose "Rotate" instead.');
-        const provided = await ask('  Paste the existing HMAC secret (or leave blank to abort): ');
-        if (!provided) {
-          throw new Error('Cannot continue without the existing webhook secret. Re-run and choose "Rotate" to generate a new one.');
-        }
-        state.webhookSecret = provided;
-        success(`Using existing webhook: ${state.webhookUrl.substring(0, 60)}...`);
-        return;
-      }
-
-      // Rotate path: disassociate the existing eventChannel, then fall through
-      // to the create branch below.
-      const confirmRotate = await askYesNo(
-        `  Confirm: delete the existing eventChannel association ${assoc.associationId} and generate a new webhook?`,
-        false
-      );
-      if (!confirmRotate) {
-        throw new Error('Rotation cancelled. Re-run the wizard when ready.');
-      }
-
-      info(`Disassociating existing eventChannel (${assoc.associationId})...`);
-      exec(
-        `aws devops-agent disassociate-service --agent-space-id ${state.agentSpaceId} --association-id ${assoc.associationId} --region ${state.agentRegion} --no-cli-pager`,
-        true
-      );
-      success('Old eventChannel association removed.');
-      // Brief pause to let the deletion settle before recreating.
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-    }
-  }
-
-  // Create a new webhook via eventChannel
-  info('Creating a new generic webhook...');
-
-  // First, register the eventChannel service
-  let serviceId: string;
-  const serviceDetailsFile = writeTempJson('event-channel-details', { eventChannel: {} });
-  try {
-    const registerResult = execJson(
-      `aws devops-agent register-service --service eventChannel --service-details file://${serviceDetailsFile} --region ${state.agentRegion} --no-cli-pager`
-    );
-    serviceId = registerResult.serviceId;
-  } catch (error: any) {
-    // Service might already be registered, try to find it
-    const services = execJson(
-      `aws devops-agent list-services --region ${state.agentRegion} --no-cli-pager`
-    );
-    const eventChannelService = services.services?.find((s: any) => s.serviceType === 'eventChannel');
-    if (eventChannelService) {
-      serviceId = eventChannelService.serviceId;
-    } else {
-      throw new Error('Failed to register eventChannel service');
-    }
-  } finally {
-    tryUnlink(serviceDetailsFile);
-  }
-
-  // Associate the eventChannel to generate the webhook
-  const eventChannelConfigFile = writeTempJson('event-channel-config', { eventChannel: {} });
-  let result: any;
-  try {
-    result = execJson(
-      `aws devops-agent associate-service --agent-space-id ${state.agentSpaceId} --service-id ${serviceId} --configuration file://${eventChannelConfigFile} --region ${state.agentRegion} --no-cli-pager`
-    );
-  } finally {
-    tryUnlink(eventChannelConfigFile);
-  }
-
-  if (result.webhook) {
-    state.webhookUrl = result.webhook.webhookUrl;
-    state.webhookSecret = result.webhook.webhookSecret;
-    success(`Webhook created: ${state.webhookUrl}`);
-    info(`Secret: ${state.webhookSecret.substring(0, 10)}... (stored securely for deployment)`);
-  } else {
-    throw new Error('Webhook was not generated in the association response');
-  }
-}
-
-/**
- * Best-effort recovery of the HMAC secret from a previously deployed
- * HealthEventAnalyzerStack-<region>. The wizard's CDK stack stores the secret
- * as a Lambda environment variable (DEVOPS_AGENT_WEBHOOK_SECRET) on the
- * InvestigationTrigger function. The CFN parameter is `noEcho`, so this is
- * the only place it is recoverable.
- *
- * Returns the secret string on success, or undefined if it can't be recovered
- * (e.g. stack not deployed yet, function not found, missing env var).
- */
-function tryRecoverSecretFromDeployedStack(state: SetupState): string | undefined {
-  const stackName = `HealthEventAnalyzerStack-${state.region}`;
-  let stackResources: any[];
-  try {
-    const resp = execJson(
-      `aws cloudformation list-stack-resources --stack-name ${stackName} --region ${state.region} --no-cli-pager`
-    );
-    stackResources = resp.StackResourceSummaries || [];
-  } catch {
-    return undefined;
-  }
-
-  const triggerLambda = stackResources.find(
-    (r: any) =>
-      r.ResourceType === 'AWS::Lambda::Function' &&
-      typeof r.LogicalResourceId === 'string' &&
-      r.LogicalResourceId.includes('InvestigationTrigger')
-  );
-  if (!triggerLambda?.PhysicalResourceId) return undefined;
-
-  try {
-    const fn = execJson(
-      `aws lambda get-function-configuration --function-name ${triggerLambda.PhysicalResourceId} --region ${state.region} --no-cli-pager`
-    );
-    const secret = fn?.Environment?.Variables?.DEVOPS_AGENT_WEBHOOK_SECRET;
-    return typeof secret === 'string' && secret.length > 0 ? secret : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-async function ensureOperatorApp(state: SetupState): Promise<void> {
-  try {
-    const operatorApp = execJson(
-      `aws devops-agent get-operator-app --agent-space-id ${state.agentSpaceId} --region ${state.agentRegion} --no-cli-pager`
-    );
-    if (operatorApp) {
-      success('Operator app already enabled');
-      state.operatorAppEnabled = true;
-      return;
-    }
-  } catch {
-    // Not enabled yet
-  }
-
-  info('Enabling operator app...');
-  exec(
-    `aws devops-agent enable-operator-app --agent-space-id ${state.agentSpaceId} --auth-flow iam --operator-app-role-arn "arn:aws:iam::${state.accountId}:role/DevOpsAgentRole-WebappAdmin" --region ${state.agentRegion} --no-cli-pager`,
-    true
-  );
-  state.operatorAppEnabled = true;
-  success('Operator app enabled (IAM auth)');
-}
+// Agent Space creation, IAM role provisioning, the AWS account association,
+// the eventChannel webhook, and the operator app used to each be a separate
+// imperative step here (createAgentSpace, ensureIamRoles, checkRoleExists,
+// ensureAccountAssociation, ensureWebhook, tryRecoverSecretFromDeployedStack,
+// ensureOperatorApp). They are now all provisioned declaratively by CDK's
+// DevOpsAgentSpaceStack (see infrastructure/cdk/lib/devops-agent-space-stack.ts
+// and lib/constructs/devops-agent-space.ts), driven from deployCdk() below.
+// pickExistingAgentSpace above is kept only for --jira-only, which attaches
+// Jira to an already-deployed Agent Space without re-running a deploy.
 
 // ─── Atlassian Jira MCP integration ─────────────────────────────────────────
 
@@ -1891,64 +1446,66 @@ async function deployCdk(state: SetupState): Promise<void> {
   execSync('npm run bundle', { cwd: cdkDir, encoding: 'utf-8', stdio: 'pipe' });
   success('Lambda functions bundled');
 
-  // Bootstrap (idempotent)
-  info('Bootstrapping CDK environment...');
-  try {
-    const bootstrapOutput = execSync(
-      `npx cdk bootstrap aws://${state.accountId}/${state.region}`,
-      { cwd: cdkDir, encoding: 'utf-8', stdio: 'pipe', env: { ...process.env, AWS_REGION: state.region, AWS_DEFAULT_REGION: state.region, CDK_DEFAULT_REGION: state.region, CDK_DEFAULT_ACCOUNT: state.accountId } }
-    );
-    // Check if output contains success indicators
-    if (bootstrapOutput.includes('already bootstrapped') || bootstrapOutput.includes('Bootstrapping environment') || bootstrapOutput.includes('✅')) {
-      success('CDK environment bootstrapped');
-    } else {
-      success('CDK environment bootstrapped');
-    }
-  } catch (bootstrapError: any) {
-    const errMsg = bootstrapError?.stderr || bootstrapError?.stdout || bootstrapError?.message || '';
-    // "already bootstrapped" or "No changes" are fine — anything else is a real failure
-    if (errMsg.includes('already bootstrapped') || errMsg.includes('No changes')) {
-      success('CDK environment already bootstrapped');
-    } else {
-      warn(`CDK bootstrap failed — retrying with explicit environment...`);
-      // Retry with explicit --trust and --cloudformation-execution-policies
-      try {
-        execSync(
-          `npx cdk bootstrap aws://${state.accountId}/${state.region} --trust ${state.accountId} --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess`,
-          { cwd: cdkDir, encoding: 'utf-8', stdio: 'inherit', env: { ...process.env, AWS_REGION: state.region, AWS_DEFAULT_REGION: state.region, CDK_DEFAULT_REGION: state.region, CDK_DEFAULT_ACCOUNT: state.accountId } }
-        );
-        success('CDK environment bootstrapped (retry succeeded)');
-      } catch (retryError: any) {
-        throw new Error(
-          `CDK bootstrap failed for aws://${state.accountId}/${state.region}. ` +
-          `Run manually: npx cdk bootstrap aws://${state.accountId}/${state.region}\n` +
-          `Error: ${retryError?.stderr || retryError?.message || retryError}`
-        );
-      }
-    }
+  // Bootstrap both regions (idempotent). The Agent Space region can differ
+  // from the deploy region (DEVOPS_AGENT_REGION) and needs its own CDK
+  // bootstrap when it does.
+  bootstrapRegion(cdkDir, state.accountId, state.region);
+  if (state.agentRegion !== state.region) {
+    bootstrapRegion(cdkDir, state.accountId, state.agentRegion);
   }
 
-  // Build deploy command — enforce --require-approval broadening for production safety
+  const agentSpaceStackName = `HealthEventAnalyzerAgentSpace-${state.agentRegion}`;
   const stackName = `HealthEventAnalyzerStack-${state.region}`;
-  const params: string[] = [
-    `--parameters DevOpsAgentWebhookUrl=${state.webhookUrl}`,
-    // Tells the stack where the Agent Space lives so the callback Lambda targets the
-    // right aidevops endpoint and its IAM policy is scoped to the right Region.
-    `--parameters DevOpsAgentRegion=${state.agentRegion}`,
-  ];
 
+  // ─── Stage 1: DevOps Agent Space stack ──────────────────────────────────
+  // Creates the Agent Space, IAM roles, operator app, AWS account
+  // association, and the eventChannel webhook. The webhook's HMAC secret is
+  // written by a custom resource directly into Secrets Manager — it never
+  // enters this script, CloudFormation state, or any CLI output (see
+  // infrastructure/cdk/lib/constructs/devops-agent-space.ts).
+  info(`Deploying DevOps Agent Space stack: ${agentSpaceStackName}`);
+  console.log('');
+  try {
+    execSync(
+      `npx cdk deploy ${agentSpaceStackName} -c devOpsAgentRegion=${state.agentRegion} --require-approval=broadening`,
+      {
+        cwd: cdkDir,
+        encoding: 'utf-8',
+        stdio: 'inherit',
+        env: { ...process.env, AWS_REGION: state.agentRegion, AWS_DEFAULT_REGION: state.agentRegion },
+      }
+    );
+    success(`Agent Space stack deployed: ${agentSpaceStackName}`);
+  } catch {
+    throw new Error(`CDK deployment failed for stack ${agentSpaceStackName}. Check the output above for details.`);
+  }
+
+  state.agentSpaceId = describeStackOutput(agentSpaceStackName, state.agentRegion, 'AgentSpaceId');
+  state.webhookUrl = describeStackOutput(agentSpaceStackName, state.agentRegion, 'WebhookUrl');
+  state.webhookSecretArn = describeStackOutput(agentSpaceStackName, state.agentRegion, 'WebhookSecretArn');
+  state.agentSpaceName = 'health-event-analyzer';
+
+  if (!state.agentSpaceId || !state.webhookUrl || !state.webhookSecretArn) {
+    throw new Error(
+      `Agent Space stack ${agentSpaceStackName} did not return all required outputs ` +
+      '(AgentSpaceId, WebhookUrl, WebhookSecretArn). Check the CloudFormation console.'
+    );
+  }
+  success(`Agent Space: ${state.agentSpaceId}`);
+  info('Webhook: configured (HMAC secret stored directly in Secrets Manager; never seen by this script)');
+
+  // ─── Stage 2: main stack ────────────────────────────────────────────────
+  const params: string[] = [];
   if (state.notificationEmail) {
     params.push(`--parameters NotificationEmail=${state.notificationEmail}`);
   }
 
-  // Store secrets in SSM Parameter Store SecureString (not as CFn parameters)
+  // Slack/MS Teams webhook secrets remain plain SSM Parameter Store
+  // SecureStrings — unrelated to the DevOps Agent webhook secret above, which
+  // now lives in Secrets Manager and is never handled here.
   const ssmPrefix = `/health-analyzer/production`;
-  info('Storing secrets in SSM Parameter Store...');
-
-  if (state.webhookSecret) {
-    putSsmSecureString(state.region, `${ssmPrefix}/webhook-secret`, state.webhookSecret,
-      'DevOps Agent HMAC webhook secret');
-    success(`SSM: ${ssmPrefix}/webhook-secret`);
+  if (state.slackWebhookUrl || state.msTeamsWebhookUrl) {
+    info('Storing Slack/MS Teams secrets in SSM Parameter Store...');
   }
   if (state.slackWebhookUrl) {
     putSsmSecureString(state.region, `${ssmPrefix}/slack-webhook-url`, state.slackWebhookUrl,
@@ -1963,8 +1520,14 @@ async function deployCdk(state: SetupState): Promise<void> {
 
   const deployCmd = [
     'npx cdk deploy',
-    '--all',
+    stackName,
     ...params,
+    // The Agent Space stack's outputs, threaded through as CDK context — the
+    // main stack has no CloudFormation parameter for these anymore (see
+    // infrastructure/cdk/lib/health-event-analyzer-stack.ts).
+    `-c devOpsAgentWebhookUrl=${state.webhookUrl}`,
+    `-c devOpsAgentWebhookSecretArn=${state.webhookSecretArn}`,
+    `-c devOpsAgentRegion=${state.agentRegion}`,
     '--require-approval=broadening',
   ].join(' ');
 
@@ -1994,6 +1557,57 @@ async function deployCdk(state: SetupState): Promise<void> {
     }
   } catch {
     // Non-critical
+  }
+}
+
+/** Bootstraps a single region/account (idempotent), retrying once with an
+ * explicit trust/execution-policy set if the plain bootstrap call fails. */
+function bootstrapRegion(cdkDir: string, accountId: string, region: string): void {
+  info(`Bootstrapping CDK environment (${region})...`);
+  try {
+    execSync(
+      `npx cdk bootstrap aws://${accountId}/${region}`,
+      { cwd: cdkDir, encoding: 'utf-8', stdio: 'pipe', env: { ...process.env, AWS_REGION: region, AWS_DEFAULT_REGION: region, CDK_DEFAULT_REGION: region, CDK_DEFAULT_ACCOUNT: accountId } }
+    );
+    success(`CDK environment bootstrapped (${region})`);
+  } catch (bootstrapError: any) {
+    const errMsg = bootstrapError?.stderr || bootstrapError?.stdout || bootstrapError?.message || '';
+    // "already bootstrapped" or "No changes" are fine — anything else is a real failure
+    if (errMsg.includes('already bootstrapped') || errMsg.includes('No changes')) {
+      success(`CDK environment already bootstrapped (${region})`);
+    } else {
+      warn(`CDK bootstrap failed in ${region} — retrying with explicit environment...`);
+      try {
+        execSync(
+          `npx cdk bootstrap aws://${accountId}/${region} --trust ${accountId} --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess`,
+          { cwd: cdkDir, encoding: 'utf-8', stdio: 'inherit', env: { ...process.env, AWS_REGION: region, AWS_DEFAULT_REGION: region, CDK_DEFAULT_REGION: region, CDK_DEFAULT_ACCOUNT: accountId } }
+        );
+        success(`CDK environment bootstrapped (retry succeeded, ${region})`);
+      } catch (retryError: any) {
+        throw new Error(
+          `CDK bootstrap failed for aws://${accountId}/${region}. ` +
+          `Run manually: npx cdk bootstrap aws://${accountId}/${region}\n` +
+          `Error: ${retryError?.stderr || retryError?.message || retryError}`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Reads a single CloudFormation stack output value via the AWS CLI. Returns
+ * an empty string when the stack, output key, or CLI call is unavailable —
+ * callers decide whether that's fatal.
+ */
+function describeStackOutput(stackName: string, region: string, outputKey: string): string {
+  try {
+    const value = exec(
+      `aws cloudformation describe-stacks --stack-name ${stackName} --region ${region} --query "Stacks[0].Outputs[?OutputKey=='${outputKey}'].OutputValue" --output text --no-cli-pager`,
+      true
+    );
+    return value === 'None' ? '' : value;
+  } catch {
+    return '';
   }
 }
 

--- a/observability/proactive-health-event-impact-analyzer/test/devops-agent-space-stack.test.ts
+++ b/observability/proactive-health-event-impact-analyzer/test/devops-agent-space-stack.test.ts
@@ -1,0 +1,154 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { DevOpsAgentSpaceStack } from '../infrastructure/cdk/lib/devops-agent-space-stack';
+
+function createStack(deployEnvironment: 'production' | 'staging' = 'production'): DevOpsAgentSpaceStack {
+  const app = new cdk.App();
+  return new DevOpsAgentSpaceStack(app, 'TestAgentSpaceStack', {
+    env: { account: '123456789012', region: 'us-east-1' },
+    projectName: 'health-event-analyzer',
+    deployEnvironment,
+  });
+}
+
+describe('DevOpsAgentSpaceStack', () => {
+  let template: Template;
+
+  beforeAll(() => {
+    template = Template.fromStack(createStack('production'));
+  });
+
+  test('creates exactly one AWS::DevOpsAgent::AgentSpace with operator app enabled', () => {
+    template.resourceCountIs('AWS::DevOpsAgent::AgentSpace', 1);
+    template.hasResourceProperties('AWS::DevOpsAgent::AgentSpace', {
+      Name: 'health-event-analyzer',
+      OperatorApp: {
+        Iam: {
+          OperatorAppRoleArn: Match.anyValue(),
+        },
+      },
+    });
+  });
+
+  test('creates the AWS account monitor association scoped to serviceId "aws"', () => {
+    template.hasResourceProperties('AWS::DevOpsAgent::Association', {
+      ServiceId: 'aws',
+      Configuration: {
+        Aws: {
+          AccountId: '123456789012',
+          AccountType: 'monitor',
+          AssumableRoleArn: Match.anyValue(),
+        },
+      },
+    });
+  });
+
+  test('AgentSpaceRole and OperatorRole are project-prefixed and trust aidevops.amazonaws.com', () => {
+    template.hasResourceProperties('AWS::IAM::Role', {
+      RoleName: 'health-event-analyzer-AgentSpaceRole',
+      AssumeRolePolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: 'Allow',
+            Principal: { Service: 'aidevops.amazonaws.com' },
+            Action: 'sts:AssumeRole',
+          }),
+        ]),
+      },
+    });
+    template.hasResourceProperties('AWS::IAM::Role', {
+      RoleName: 'health-event-analyzer-OperatorRole',
+    });
+  });
+
+  test('AgentSpaceRole uses the AIDevOpsAgentAccessPolicy managed policy; OperatorRole uses AIDevOpsOperatorAppAccessPolicy', () => {
+    const roles = template.findResources('AWS::IAM::Role');
+    const roleValues = Object.values(roles) as any[];
+
+    const findByName = (name: string) => roleValues.find((r) => r.Properties?.RoleName === name);
+
+    const agentSpaceRole = findByName('health-event-analyzer-AgentSpaceRole');
+    const operatorRole = findByName('health-event-analyzer-OperatorRole');
+    expect(agentSpaceRole).toBeDefined();
+    expect(operatorRole).toBeDefined();
+
+    const arnContains = (managedPolicyArns: any[], suffix: string) =>
+      managedPolicyArns.some((arn) => JSON.stringify(arn).includes(suffix));
+
+    expect(arnContains(agentSpaceRole.Properties.ManagedPolicyArns, 'AIDevOpsAgentAccessPolicy')).toBe(true);
+    expect(arnContains(operatorRole.Properties.ManagedPolicyArns, 'AIDevOpsOperatorAppAccessPolicy')).toBe(true);
+  });
+
+  test('creates a Secrets Manager secret for the webhook HMAC key with DESTROY removal policy', () => {
+    template.hasResource('AWS::SecretsManager::Secret', {
+      DeletionPolicy: 'Delete',
+      UpdateReplacePolicy: 'Delete',
+    });
+  });
+
+  test('creates the webhook provisioner custom resource depending on the Agent Space', () => {
+    template.hasResource('Custom::DevOpsAgentWebhook', {
+      DependsOn: Match.arrayWith([Match.stringLikeRegexp('SpaceAgentSpace')]),
+    });
+  });
+
+  test('webhook provisioner Lambda role is scoped to specific aidevops actions (no full aidevops:* wildcard)', () => {
+    const policies = template.findResources('AWS::IAM::Policy');
+    const policyValues = Object.values(policies) as any[];
+
+    let found = false;
+    for (const policy of policyValues) {
+      const statements = policy.Properties?.PolicyDocument?.Statement;
+      if (!Array.isArray(statements)) continue;
+      for (const stmt of statements) {
+        if (stmt.Sid === 'DevOpsAgentWebhookLifecycle') {
+          found = true;
+          const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+          expect(actions).toEqual(
+            expect.arrayContaining([
+              'aidevops:RegisterService',
+              'aidevops:ListServices',
+              'aidevops:AssociateService',
+              'aidevops:DisassociateService',
+              'aidevops:ListAssociations',
+            ])
+          );
+          expect(actions).not.toContain('aidevops:*');
+        }
+      }
+    }
+    expect(found).toBe(true);
+  });
+
+  test('outputs AgentSpaceId, AgentSpaceArn, WebhookUrl, WebhookSecretArn, AgentSpaceRoleArn, OperatorRoleArn', () => {
+    template.hasOutput('AgentSpaceId', {});
+    template.hasOutput('AgentSpaceArn', {});
+    template.hasOutput('WebhookUrl', {});
+    template.hasOutput('WebhookSecretArn', {});
+    template.hasOutput('AgentSpaceRoleArn', {});
+    template.hasOutput('OperatorRoleArn', {});
+  });
+
+  test('webhook provisioner Lambda uses the Node.js 24 runtime', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Runtime: 'nodejs24.x',
+      Handler: 'index.handler',
+    });
+  });
+});
+
+describe('DevOpsAgentSpaceStack - log retention matches deployment environment', () => {
+  test('production webhook provisioner log group uses 90-day retention', () => {
+    const template = Template.fromStack(createStack('production'));
+    template.hasResourceProperties('AWS::Logs::LogGroup', {
+      RetentionInDays: 90,
+    });
+  });
+
+  test('staging webhook provisioner log group uses 14-day retention', () => {
+    const template = Template.fromStack(createStack('staging'));
+    template.hasResourceProperties('AWS::Logs::LogGroup', {
+      RetentionInDays: 14,
+    });
+  });
+});

--- a/observability/proactive-health-event-impact-analyzer/test/health-event-analyzer.test.ts
+++ b/observability/proactive-health-event-impact-analyzer/test/health-event-analyzer.test.ts
@@ -11,10 +11,16 @@ function createTestApp(environment?: string): cdk.App {
   return new cdk.App({ context });
 }
 
-// Helper to create a stack with proper env for synthesis
+// Helper to create a stack with proper env for synthesis. The DevOps Agent
+// webhook URL/secret ARN are now supplied via typed props (populated by CDK
+// context in the real app — see bin/app.ts) instead of CloudFormation
+// parameters, since the Agent Space that produces them is now CDK-managed
+// (DevOpsAgentSpaceStack) rather than pasted in by hand.
 function createTestStack(app: cdk.App, id: string): HealthEventAnalyzerStack {
   return new HealthEventAnalyzerStack(app, id, {
     env: { account: '123456789012', region: 'us-east-1' },
+    devOpsAgentWebhookUrl: 'https://example.com/webhook',
+    devOpsAgentWebhookSecretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-webhook-secret-abc123',
   });
 }
 
@@ -149,14 +155,26 @@ describe('HealthEventAnalyzerStack', () => {
     template.hasOutput('StateMachineArn', {});
   });
 
-  test('has required parameters for DevOps Agent', () => {
-    template.hasParameter('DevOpsAgentWebhookUrl', {
-      Type: 'String',
+  test('DevOps Agent webhook URL flows to the Investigation Trigger Lambda (no CloudFormation parameter)', () => {
+    // The webhook URL is now a typed stack prop sourced from CDK context
+    // (populated by scripts/setup-wizard.ts after reading the CDK-managed
+    // DevOpsAgentSpaceStack's outputs) rather than a CloudFormation parameter
+    // an operator pastes in by hand.
+    const params = template.findParameters('*');
+    expect(Object.keys(params)).not.toContain('DevOpsAgentWebhookUrl');
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Description: Match.stringLikeRegexp('Triggers AWS DevOps Agent investigation'),
+      Environment: {
+        Variables: Match.objectLike({
+          DEVOPS_AGENT_WEBHOOK_URL: 'https://example.com/webhook',
+        }),
+      },
     });
   });
 });
 
-describe('HealthEventAnalyzerStack - SSM Parameter Store Secrets', () => {
+describe('HealthEventAnalyzerStack - Secrets Manager and SSM Parameter Store Secrets', () => {
   let template: Template;
 
   beforeAll(() => {
@@ -174,12 +192,17 @@ describe('HealthEventAnalyzerStack - SSM Parameter Store Secrets', () => {
     expect(paramNames).not.toContain('MsTeamsWebhookUrl');
   });
 
-  test('Investigation Trigger Lambda has WEBHOOK_SECRET_PARAM_NAME env var with SSM path (not value)', () => {
+  test('Investigation Trigger Lambda has WEBHOOK_SECRET_ARN and WEBHOOK_SECRET_REGION env vars (not the secret value)', () => {
+    // The DevOps Agent webhook secret is now provisioned by the CDK-managed
+    // DevOpsAgentSpaceStack directly into Secrets Manager (see
+    // lib/constructs/devops-agent-space.ts) — the Lambda gets only the ARN
+    // and region, and reads the value at runtime via getSecretFromSecretsManager.
     template.hasResourceProperties('AWS::Lambda::Function', {
       Description: Match.stringLikeRegexp('Triggers AWS DevOps Agent investigation'),
       Environment: {
         Variables: Match.objectLike({
-          WEBHOOK_SECRET_PARAM_NAME: '/health-analyzer/production/webhook-secret',
+          WEBHOOK_SECRET_ARN: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-webhook-secret-abc123',
+          WEBHOOK_SECRET_REGION: 'us-east-1',
         }),
       },
     });
@@ -233,17 +256,14 @@ describe('HealthEventAnalyzerStack - SSM Parameter Store Secrets', () => {
     }
   });
 
-  test('Investigation Trigger Lambda has ssm:GetParameter scoped to webhook-secret ARN', () => {
+  test('Investigation Trigger Lambda has secretsmanager:GetSecretValue scoped to the webhook secret ARN', () => {
     template.hasResourceProperties('AWS::IAM::Policy', {
       PolicyDocument: {
         Statement: Match.arrayWith([
           Match.objectLike({
-            Sid: 'ReadWebhookSecret',
-            Action: 'ssm:GetParameter',
+            Action: Match.arrayWith(['secretsmanager:GetSecretValue']),
             Effect: 'Allow',
-            Resource: {
-              'Fn::Join': Match.anyValue(),
-            },
+            Resource: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-webhook-secret-abc123',
           }),
         ]),
       },
@@ -264,19 +284,10 @@ describe('HealthEventAnalyzerStack - SSM Parameter Store Secrets', () => {
     });
   });
 
-  test('SSM parameter paths use environment prefix for staging', () => {
+  test('SSM parameter paths use environment prefix for staging (Slack/MS Teams; webhook secret is Secrets Manager, not SSM)', () => {
     const app = createTestApp('staging');
     const stack = createTestStack(app, 'StagingSSMStack');
     const stagingTemplate = Template.fromStack(stack);
-
-    stagingTemplate.hasResourceProperties('AWS::Lambda::Function', {
-      Description: Match.stringLikeRegexp('Triggers AWS DevOps Agent investigation'),
-      Environment: {
-        Variables: Match.objectLike({
-          WEBHOOK_SECRET_PARAM_NAME: '/health-analyzer/staging/webhook-secret',
-        }),
-      },
-    });
 
     stagingTemplate.hasResourceProperties('AWS::Lambda::Function', {
       Description: Match.stringLikeRegexp('Routes impact notifications to affected teams'),
@@ -1526,19 +1537,40 @@ describe('HealthEventAnalyzerStack - No Hardcoded Secrets (Requirement 2.6)', ()
     }
   });
 
-  test('no Lambda environment variables contain webhook URL values (only parameter names) (Req 2.6)', () => {
+  test('no Lambda environment variables contain secret-bearing webhook URL values (only parameter names/ARNs) (Req 2.6)', () => {
     const lambdas = template.findResources('AWS::Lambda::Function');
+
+    // DEVOPS_AGENT_WEBHOOK_URL is intentionally excluded: it is the public
+    // endpoint the trigger Lambda POSTs to, not a secret — the sensitive part
+    // is the separate HMAC signing secret, which lives in Secrets Manager
+    // (WEBHOOK_SECRET_ARN, not the value itself) and is checked below.
+    const nonSecretUrlEnvVars = ['DEVOPS_AGENT_WEBHOOK_URL'];
 
     for (const [, resource] of Object.entries(lambdas)) {
       const envVars = (resource as any).Properties?.Environment?.Variables ?? {};
       for (const [key, value] of Object.entries(envVars)) {
+        if (nonSecretUrlEnvVars.includes(key)) continue;
         if (typeof value === 'string') {
-          // Values should be SSM parameter paths, not actual URLs
+          // Values should be SSM parameter paths / Secrets Manager ARNs, not actual URLs
           expect(value).not.toMatch(/^https?:\/\//);
           // Should not look like a secret/token
           expect(value).not.toMatch(/^(sk-|xoxb-|Bearer )/);
         }
       }
+    }
+  });
+
+  test('WEBHOOK_SECRET_ARN env var is an ARN, never the secret value itself (Req 2.6)', () => {
+    const lambdas = template.findResources('AWS::Lambda::Function', {
+      Properties: {
+        Description: Match.stringLikeRegexp('Triggers AWS DevOps Agent investigation'),
+      },
+    });
+    for (const [, resource] of Object.entries(lambdas)) {
+      const envVars = (resource as any).Properties?.Environment?.Variables ?? {};
+      const secretArn = envVars.WEBHOOK_SECRET_ARN;
+      expect(typeof secretArn).toBe('string');
+      expect(secretArn).toMatch(/^arn:aws:secretsmanager:/);
     }
   });
 
@@ -1600,7 +1632,34 @@ describe('HealthEventAnalyzerStack - SSM GetParameter Scoping (Requirement 2.5 -
     expect(ssmGetParamStatements).toBeGreaterThanOrEqual(2);
   });
 
-  test('Investigation Trigger ssm:GetParameter resource contains webhook-secret path', () => {
+  test('Investigation Trigger ssm:GetParameter resource contains the Jira routing config path (not the webhook secret — that is Secrets Manager now)', () => {
+    const policies = template.findResources('AWS::IAM::Policy');
+    const policyValues = Object.values(policies);
+
+    let foundJiraConfigGrant = false;
+
+    for (const policy of policyValues) {
+      const statements = policy.Properties?.PolicyDocument?.Statement;
+      if (!Array.isArray(statements)) continue;
+      for (const stmt of statements) {
+        if (stmt.Sid === 'ReadJiraRoutingConfig') {
+          foundJiraConfigGrant = true;
+          const resources = Array.isArray(stmt.Resource) ? stmt.Resource : [stmt.Resource];
+          for (const resource of resources) {
+            if (resource?.['Fn::Join']) {
+              const joinParts = resource['Fn::Join'][1];
+              const joinedStr = joinParts.filter((p: any) => typeof p === 'string').join('');
+              expect(joinedStr).toContain('/health-analyzer/jira/');
+            }
+          }
+        }
+      }
+    }
+
+    expect(foundJiraConfigGrant).toBe(true);
+  });
+
+  test('Investigation Trigger has secretsmanager:GetSecretValue scoped to the webhook secret ARN (not SSM)', () => {
     const policies = template.findResources('AWS::IAM::Policy');
     const policyValues = Object.values(policies);
 
@@ -1610,16 +1669,9 @@ describe('HealthEventAnalyzerStack - SSM GetParameter Scoping (Requirement 2.5 -
       const statements = policy.Properties?.PolicyDocument?.Statement;
       if (!Array.isArray(statements)) continue;
       for (const stmt of statements) {
-        if (stmt.Sid === 'ReadWebhookSecret' && stmt.Action === 'ssm:GetParameter') {
+        const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+        if (actions.includes('secretsmanager:GetSecretValue') && stmt.Resource === 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-webhook-secret-abc123') {
           foundWebhookSecretGrant = true;
-          // The resource should be a Fn::Join that builds the ARN
-          const resource = stmt.Resource;
-          if (resource?.['Fn::Join']) {
-            const joinParts = resource['Fn::Join'][1];
-            const joinedStr = joinParts.filter((p: any) => typeof p === 'string').join('');
-            expect(joinedStr).toContain('/health-analyzer/');
-            expect(joinedStr).toContain('webhook-secret');
-          }
         }
       }
     }
@@ -1967,23 +2019,25 @@ describe('HealthEventAnalyzerStack - Environment-Specific Configuration Differen
     }
   });
 
-  test('SSM parameter paths differ between production and staging', () => {
-    // Production uses /health-analyzer/production/... paths
+  test('SSM parameter paths differ between production and staging (Notifier); the webhook secret ARN is environment-agnostic', () => {
+    // The DevOps Agent webhook secret now comes from Secrets Manager via a
+    // typed prop (see the DevOpsAgentSpaceStack), not an environment-prefixed
+    // SSM path, so it is identical across environments in this test — the
+    // real environment-prefixed paths that remain are Slack/MS Teams (SSM).
     prodTemplate.hasResourceProperties('AWS::Lambda::Function', {
-      Description: Match.stringLikeRegexp('Triggers AWS DevOps Agent investigation'),
+      Description: Match.stringLikeRegexp('Routes impact notifications to affected teams'),
       Environment: {
         Variables: Match.objectLike({
-          WEBHOOK_SECRET_PARAM_NAME: '/health-analyzer/production/webhook-secret',
+          SLACK_WEBHOOK_PARAM_NAME: '/health-analyzer/production/slack-webhook-url',
         }),
       },
     });
 
-    // Staging uses /health-analyzer/staging/... paths
     stagingTemplate.hasResourceProperties('AWS::Lambda::Function', {
-      Description: Match.stringLikeRegexp('Triggers AWS DevOps Agent investigation'),
+      Description: Match.stringLikeRegexp('Routes impact notifications to affected teams'),
       Environment: {
         Variables: Match.objectLike({
-          WEBHOOK_SECRET_PARAM_NAME: '/health-analyzer/staging/webhook-secret',
+          SLACK_WEBHOOK_PARAM_NAME: '/health-analyzer/staging/slack-webhook-url',
         }),
       },
     });

--- a/observability/proactive-health-event-impact-analyzer/test/lambda-logic.test.ts
+++ b/observability/proactive-health-event-impact-analyzer/test/lambda-logic.test.ts
@@ -3,6 +3,9 @@
  * Tests correlation extraction, link generation, category mapping, and severity mapping.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
+
 describe('Investigation Callback — Correlation', () => {
   // Simulate the extractCorrelationKey logic
   function extractTag(text: string, prefix: string): string | null {
@@ -419,17 +422,34 @@ describe('Investigation Trigger — Exponential Backoff Calculation', () => {
   });
 });
 
-describe('Investigation Trigger — Secrets Cache Integration', () => {
-  test('uses WEBHOOK_SECRET_PARAM_NAME env var (not DEVOPS_AGENT_WEBHOOK_SECRET)', () => {
-    // Verify that the Lambda reads the SSM parameter name from the env var
-    // and uses getSecret() to fetch the actual value at runtime.
-    // This is a design verification test — the actual integration is tested
-    // via the CDK assertion tests that verify the environment variable name.
-    const envVarName = 'WEBHOOK_SECRET_PARAM_NAME';
-    const envVarValue = '/health-analyzer/production/webhook-secret';
+describe('Investigation Trigger — Secrets Manager Integration', () => {
+  // The DevOps Agent webhook secret now lives in Secrets Manager (provisioned
+  // by the CDK-managed DevOpsAgentSpaceStack — see
+  // infrastructure/cdk/lib/constructs/devops-agent-space.ts), not SSM
+  // Parameter Store. The Lambda reads it via WEBHOOK_SECRET_ARN +
+  // WEBHOOK_SECRET_REGION and getSecretFromSecretsManager(), never
+  // WEBHOOK_SECRET_PARAM_NAME/getSecret() for this value. Slack/MS Teams
+  // webhook secrets are unaffected and remain SSM SecureStrings.
+  const investigationTriggerSource = fs.readFileSync(
+    path.resolve(__dirname, '../infrastructure/cdk/lambda/investigation-trigger/index.ts'),
+    'utf-8'
+  );
 
-    // The env var should be an SSM parameter path, not a secret value
-    expect(envVarValue).toMatch(/^\/health-analyzer\//);
-    expect(envVarValue).not.toMatch(/^[a-zA-Z0-9+/=]{20,}$/); // Not a base64 secret
+  test('reads the webhook secret via getSecretFromSecretsManager, not getSecret (SSM)', () => {
+    expect(investigationTriggerSource).toContain('getSecretFromSecretsManager');
+    expect(investigationTriggerSource).toContain('WEBHOOK_SECRET_ARN');
+    expect(investigationTriggerSource).toContain('WEBHOOK_SECRET_REGION');
+  });
+
+  test('does not reference the retired SSM-based webhook secret env var or plaintext secret env var', () => {
+    expect(investigationTriggerSource).not.toContain('WEBHOOK_SECRET_PARAM_NAME');
+    expect(investigationTriggerSource).not.toContain('DEVOPS_AGENT_WEBHOOK_SECRET');
+  });
+
+  test('still uses SSM getParameters for the unrelated Jira routing config', () => {
+    // Confirms the Jira config path (unrelated to this migration) was left
+    // on SSM Parameter Store, not accidentally moved to Secrets Manager too.
+    expect(investigationTriggerSource).toContain('GetParametersCommand');
+    expect(investigationTriggerSource).toContain('/health-analyzer/jira/');
   });
 });

--- a/observability/proactive-health-event-impact-analyzer/test/setup-wizard.test.ts
+++ b/observability/proactive-health-event-impact-analyzer/test/setup-wizard.test.ts
@@ -166,13 +166,26 @@ describe('setup-wizard production readiness', () => {
     });
 
     it('uses runStep for major wizard steps in main flow', () => {
-      // The main flow should use runStep for key steps
+      // The main flow should use runStep for key steps. DevOps Agent Space
+      // creation, IAM roles, the account association, and the webhook used
+      // to each be separate imperative runStep-wrapped steps here — they are
+      // now provisioned declaratively by CDK (DevOpsAgentSpaceStack) as part
+      // of the single 'CDK Deployment' step below.
       expect(wizardSource).toContain("runStep('Check prerequisites'");
-      expect(wizardSource).toContain("runStep('DevOps Agent Space'");
-      expect(wizardSource).toContain("runStep('IAM Roles'");
-      expect(wizardSource).toContain("runStep('Account Association'");
-      expect(wizardSource).toContain("runStep('Webhook Configuration'");
       expect(wizardSource).toContain("runStep('CDK Deployment'");
+      expect(wizardSource).toContain("runStep('Jira Integration'");
+      expect(wizardSource).not.toContain("runStep('DevOps Agent Space'");
+      expect(wizardSource).not.toContain("runStep('IAM Roles'");
+      expect(wizardSource).not.toContain("runStep('Account Association'");
+      expect(wizardSource).not.toContain("runStep('Webhook Configuration'");
+    });
+
+    it('Jira integration runs after the CDK deployment step (Agent Space must exist first)', () => {
+      const cdkDeployIdx = wizardSource.indexOf("runStep('CDK Deployment'");
+      const jiraIdx = wizardSource.indexOf("runStep('Jira Integration'");
+      expect(cdkDeployIdx).toBeGreaterThan(-1);
+      expect(jiraIdx).toBeGreaterThan(-1);
+      expect(cdkDeployIdx).toBeLessThan(jiraIdx);
     });
   });
 
@@ -257,13 +270,31 @@ describe('setup-wizard production readiness', () => {
       expect(fnBody).not.toContain('--require-approval never');
     });
 
-    it('deployCdk stores secrets in SSM SecureString before deploying', () => {
+    it('deployCdk stores the Slack/MS Teams secrets in SSM SecureString before deploying the main stack', () => {
       const fnBody = extractFunctionSource(wizardSource, 'async function deployCdk');
       expect(fnBody).not.toBe('');
       expect(fnBody).toContain('putSsmSecureString');
-      expect(fnBody).toContain('webhook-secret');
       expect(fnBody).toContain('slack-webhook-url');
       expect(fnBody).toContain('msteams-webhook-url');
+    });
+
+    it('deployCdk does NOT store the DevOps Agent webhook secret via SSM (it is Secrets Manager now)', () => {
+      const fnBody = extractFunctionSource(wizardSource, 'async function deployCdk');
+      expect(fnBody).not.toBe('');
+      expect(fnBody).not.toContain('webhook-secret');
+      expect(fnBody).not.toContain('DEVOPS_AGENT_WEBHOOK_SECRET');
+    });
+
+    it('deployCdk reads the Agent Space stack outputs (AgentSpaceId, WebhookUrl, WebhookSecretArn) instead of driving the AWS CLI directly', () => {
+      const fnBody = extractFunctionSource(wizardSource, 'async function deployCdk');
+      expect(fnBody).not.toBe('');
+      expect(fnBody).toContain('describeStackOutput');
+      expect(fnBody).toContain("'AgentSpaceId'");
+      expect(fnBody).toContain("'WebhookUrl'");
+      expect(fnBody).toContain("'WebhookSecretArn'");
+      expect(fnBody).toContain('devOpsAgentWebhookSecretArn=');
+      expect(fnBody).not.toContain('aws devops-agent create-agent-space');
+      expect(fnBody).not.toContain('aws devops-agent associate-service');
     });
 
     it('deployCdk does not pass secrets as CloudFormation parameters', () => {


### PR DESCRIPTION
## Summary

Replaces the imperative `aws devops-agent` CLI flow that `scripts/setup-wizard.ts` used to drive by hand (Agent Space creation, IAM roles, account association, webhook, operator app) with a dedicated CDK stack, `DevOpsAgentSpaceStack`, using `AWS::DevOpsAgent::AgentSpace` / `AWS::DevOpsAgent::Association` L1 constructs.

This mirrors the pattern already reviewed and merged for the sibling `eks-investigation-devops-agent` demo (#89dc36b), per maintainer request to move this demo off the CLI flow too.

## What changed

- **New `DevOpsAgentSpace` construct** (`infrastructure/cdk/lib/constructs/devops-agent-space.ts`): two IAM roles, `AWS::DevOpsAgent::AgentSpace` (with operator app), `AWS::DevOpsAgent::Association` (account monitor), and a Lambda-backed custom resource that provisions the `eventChannel` webhook.
- **Webhook secret → Secrets Manager**: AWS DevOps Agent returns the webhook HMAC secret exactly once, in `AssociateService`'s create response — no `Describe`/`List` call returns it again, and neither `AWS::DevOpsAgent::Association` nor `AWS::DevOpsAgent::Service` can express reading it back or registering the `eventChannel` service type. The custom resource writes the secret directly into a Secrets Manager secret; it never enters CloudFormation state, outputs, or the repo's scripts. `investigation-trigger` now reads it via ARN + region instead of an SSM parameter name. Slack/MS Teams webhook secrets are untouched (still SSM SecureStrings).
- **Two-stack deploy**: `bin/app.ts` deploys `DevOpsAgentSpaceStack` first (optionally to a different region via `devOpsAgentRegion` context, since an Agent Space monitors all regions of its account) and threads its `WebhookUrl`/`WebhookSecretArn` outputs into `HealthEventAnalyzerStack` as CDK context, replacing the old `DevOpsAgentWebhookUrl`/`DevOpsAgentRegion` CloudFormation parameters.
- **`scripts/setup-wizard.ts`**: removed the imperative Agent Space/IAM/association/webhook/operator-app steps entirely. The wizard now deploys the Agent Space stack, reads its outputs back with `aws cloudformation describe-stacks`, and deploys the main stack with those as context. The Atlassian Jira step now runs *after* the deploy, since it needs the Agent Space ID that step produces.
- **`scripts/cleanup.ts`**: the Agent Space, its roles, association, operator app, and webhook are now torn down by `cdk destroy` on the Agent Space stack instead of imperative disassociate/delete calls.
- No `aws-cdk-lib` version bump needed — confirmed the already-pinned `2.260.0` fully supports `CfnAgentSpace`/`CfnAssociation`/`CfnService` including `OperatorApp` and the `Aws` association configuration used here.
- Added `cdk-nag` suppressions (IAM4/IAM5/L1/SMG4) for the new stack with documented justifications (this demo runs `AwsSolutionsChecks`; the sibling demo does not).
- Updated README/ARCHITECTURE/docs for the new two-stack deploy flow (including manual deployment steps), and added `test/devops-agent-space-stack.test.ts` plus updates to the existing CDK/wizard/lambda-logic tests for the new topology.

## Testing

- `npm run build` and `npm test` (268/268) pass; `cdk synth` is clean for both stacks, including cross-region wiring and the pre-deploy placeholder-secret fallback.
- Deployed both stacks to a real account end-to-end via `deploy-all.ps1` (fresh Agent Space, roles, association, and webhook all created by CDK with no manual steps).
- Fired a test Health event through Event Router → Step Functions → the new Agent Space's webhook → DevOps Agent investigation → callback. Completed successfully (LOW-impact result correctly skipped OpsItem/notification, confirming the full round trip works against the CDK-provisioned Agent Space).