### PR TITLE
fix(resilience): enable prompt caching and stop polling DLT through the model loop

### DIFF
--- a/resilience/ai-load-test-generation-with-dlt/README.md
+++ b/resilience/ai-load-test-generation-with-dlt/README.md
@@ -502,12 +502,13 @@ generated script grows, how many smoke-and-fix iterations it takes, and how long
 you poll a run. A wide scope on a large spec can be several times the figure
 above.
 
-Two settings matter here. Prompt caching is on by default
+Two settings move it more than anything else. Prompt caching is on by default
 (`CacheConfig(strategy="auto")` in `agent.py`), which is what makes the repeated
 resends cheap; there is no storage charge for it, only a per-token cache-write
-and a much lower cache-read rate. And the model is a straight swap — Sonnet 5
-lists well below Opus for both input and output, and held every safety gate in
-our testing: `--bedrock-model us.anthropic.claude-sonnet-5`.
+and a much lower cache-read rate. And the model is a straight swap: Sonnet 5 held
+every safety gate in our testing — `--bedrock-model us.anthropic.claude-sonnet-5`.
+For scale: one measured cycle over two endpoints at 5 VUs came to **\$2.32** in
+inference on the default model, and **\$0.48** on Sonnet 5.
 
 **Optimization:** default to `public` unless you need private egress/targets; scope
 the test to the endpoints you actually care about rather than the whole spec; tear

--- a/resilience/ai-load-test-generation-with-dlt/README.md
+++ b/resilience/ai-load-test-generation-with-dlt/README.md
@@ -489,7 +489,28 @@ negligible S3/ECR storage. This is the cheapest way to run the demo.
 endpoints** (~\$7/mo each, ×~5) on top of the above. A demo of a few hours is a few
 USD, dominated by NAT + endpoints.
 
-**Optimization:** default to `public` unless you need private egress/targets; tear
+**Per cycle:** roughly **\$2–5** in Bedrock inference for one end-to-end cycle
+(parse a spec, classify endpoints, build a script, smoke it, register the
+scenario, run the load, interpret the results). Inference dominates; the DLT run
+itself is Fargate task time and is comparatively small.
+
+Costs vary a lot with the shape of the work. A cycle is a tool loop, not a
+two-message chat: the model is re-invoked once per tool call and each invocation
+resends the conversation so far, so anything that lengthens the loop moves the
+bill — the number of endpoints in scope, the size of the spec, how large the
+generated script grows, how many smoke-and-fix iterations it takes, and how long
+you poll a run. A wide scope on a large spec can be several times the figure
+above.
+
+Two settings matter here. Prompt caching is on by default
+(`CacheConfig(strategy="auto")` in `agent.py`), which is what makes the repeated
+resends cheap; there is no storage charge for it, only a per-token cache-write
+and a much lower cache-read rate. And the model is a straight swap — Sonnet 5
+lists well below Opus for both input and output, and held every safety gate in
+our testing: `--bedrock-model us.anthropic.claude-sonnet-5`.
+
+**Optimization:** default to `public` unless you need private egress/targets; scope
+the test to the endpoints you actually care about rather than the whole spec; tear
 down when idle; keep X-Ray off unless Transaction Search is enabled.
 
 ## Teardown

--- a/resilience/ai-load-test-generation-with-dlt/README.md
+++ b/resilience/ai-load-test-generation-with-dlt/README.md
@@ -260,8 +260,9 @@ registered, and the approval summary it showed you. That state is keyed by
 starts from scratch. Ids must be at least 33 characters.
 
 Session state lives in the runtime's per-session microVM. It survives between
-invocations but is discarded when the session ends (15 min idle, or 8 h max), so
-finish a test run in one sitting.
+invocations but is discarded when the session ends (15 min idle, or 8 h max) — so
+build and register in one sitting. A run itself is not tied to the session: its
+test id is enough to fetch results from a fresh one.
 
 ```bash
 SESSION="session-$(uuidgen | tr -d -)0"
@@ -278,7 +279,7 @@ JSON
 }
 ```
 
-### Worked example — spec to load test in five turns
+### Worked example — spec to load test in three turns
 
 This is a real session, with the target host and bucket replaced by placeholders.
 It uses `sample-data/swagger-unified.json` (staged to `s3://$BUCKET/swagger.json`
@@ -368,55 +369,44 @@ the guard records the decision, it cannot make it for you.
 
 ```bash
 say 'Approved. I have read the summary above — prod target, 10 VUs, 30s ramp-up,
-5 min hold, 50/50 read-only. Run it now. Do not block-poll; just start it and
-report the run status.'
+5 min hold, 50/50 read-only. Run it now, then give me the results.'
 ```
 
-```
-🚀 Load test started.
-Test ID: concert-read-path   Status: queued   Started: 2026-01-01 12:00:00 UTC
-Lifecycle: queued → provisioning (~90s) → running → complete (~7 min wall-clock).
-```
-
-**4. Check on it.** Ask for a single read rather than letting it poll in a loop —
-polling inside one turn just burns model tokens waiting.
-
-```bash
-sleep 150 && say 'Status check please. Single read, no block-polling.'
-```
+This turn does not come back until the run is over — about 8.5 minutes here. It
+waits inside `poll_test_status` rather than asking you to check again, then
+reports per-endpoint numbers, whether the split and the correlation actually
+worked, and what the numbers do **not** prove.
 
 ```
-Status: running — provisioning is done, load is actively being generated.
-Task failures so far: 0
-```
-
-**5. Get the results.** It reports per-endpoint numbers, checks the split and the
-correlation actually worked, and says what the numbers do **not** prove.
-
-```bash
-sleep 330 && say 'Status check again. If it is complete, fetch the results and
-interpret them. Verify the 50/50 split and the setup seeding as you said you would.'
-```
-
-```
-✅ Test complete — task_failure_count = 0. Load phase 325s.
+✅ Test complete — task_failure_count = 0, 0 failed samples of 2,219.
 
 Setup seeding ✅  TX_Seed_ConcertId: succ = 10, fail = 0 — one seed per VU; no
 detail request ran against the EXTRACT_FAILED sentinel.
 
 50/50 split ✅
-TX_List_Concerts        1,086   49.7%
-TX_Get_Concert_Detail   1,098   50.3%
+TX_List_Concerts        1,106   50.1%
+TX_Get_Concert_Detail   1,103   49.9%
 
-Aggregate: avg 0.181s, p50 0.176s, p95 0.188s, p99 0.344s.
-0 errors across 2,194 samples.
+Aggregate: avg 0.176s, p50 0.171s, p95 0.178s, p99 0.334s.
 
 Caveats: these are DLT client-side metrics only — they say what the client saw,
-not why. Separating server latency from network needs CloudWatch/X-Ray on the
-service side.
+not why. DLT ran in us-east-2 against an ap-northeast-2 target, so ~170ms of
+round trip is in every figure above. Separating server latency from network
+needs CloudWatch/X-Ray on the service side.
+
+Handle: concert-read-path — reusable to re-fetch these results later.
 ```
 
-Three things to know before you copy this.
+Four things to know before you copy this.
+
+**A long run needs a second turn, a short one does not.** `poll_test_status` can
+wait inside the call — a sleep there costs nothing, while asking the model to read
+the status again costs a full round trip of the whole conversation. That is why the
+walkthrough above gets results in one turn instead of a `sleep && ask` loop. But
+AgentCore kills a synchronous request at 15 minutes, so waiting is capped and only
+offered while the run has under 10 minutes left. Past that the agent hands back the
+test id and you collect the results whenever you like — the id works from a fresh
+session, so nothing depends on the first one still being alive.
 
 **Which numbers are baked into the script, and which are not.** Turn 1 states the
 load profile for convenience, but only *scope* and *ratio* actually end up in the
@@ -489,26 +479,33 @@ negligible S3/ECR storage. This is the cheapest way to run the demo.
 endpoints** (~\$7/mo each, ×~5) on top of the above. A demo of a few hours is a few
 USD, dominated by NAT + endpoints.
 
-**Per cycle:** roughly **\$2–5** in Bedrock inference for one end-to-end cycle
-(parse a spec, classify endpoints, build a script, smoke it, register the
-scenario, run the load, interpret the results). Inference dominates; the DLT run
-itself is Fargate task time and is comparatively small.
+**Per cycle:** on the order of **\$1** in Bedrock inference for one end-to-end
+cycle (parse a spec, classify endpoints, build a script, smoke it, register the
+scenario, run the load, interpret the results) — treat that as an order of
+magnitude, not a quote. What you actually pay depends on your environment and on
+what you asked for. Inference dominates; the DLT run itself is Fargate task time
+and is comparatively small.
 
 Costs vary a lot with the shape of the work. A cycle is a tool loop, not a
 two-message chat: the model is re-invoked once per tool call and each invocation
 resends the conversation so far, so anything that lengthens the loop moves the
 bill — the number of endpoints in scope, the size of the spec, how large the
-generated script grows, how many smoke-and-fix iterations it takes, and how long
-you poll a run. A wide scope on a large spec can be several times the figure
-above.
+generated script grows, and how many smoke-and-fix iterations it takes. A wide
+scope on a large spec can be several times the figure above.
+
+One thing that does *not* move it is the load itself. Two cycles over the same two
+endpoints — 5 VUs for 1 minute, and 10 VUs for 5 minutes — cost the same, even
+though the second generated nine times the requests and took eight minutes longer.
+Waiting for a run happens inside a tool call, where a sleep costs nothing; only a
+model round trip costs tokens. So a longer or heavier test is not a more expensive
+one; a broader scope is.
 
 Two settings move it more than anything else. Prompt caching is on by default
 (`CacheConfig(strategy="auto")` in `agent.py`), which is what makes the repeated
 resends cheap; there is no storage charge for it, only a per-token cache-write
-and a much lower cache-read rate. And the model is a straight swap: Sonnet 5 held
-every safety gate in our testing — `--bedrock-model us.anthropic.claude-sonnet-5`.
-For scale: one measured cycle over two endpoints at 5 VUs came to **\$2.32** in
-inference on the default model, and **\$0.48** on Sonnet 5.
+and a much lower cache-read rate. And the model is a straight swap: on the same
+walkthrough Sonnet 5 held every safety gate, waited out the run the same way, and
+came to half the inference cost — `--bedrock-model us.anthropic.claude-sonnet-5`.
 
 **Optimization:** default to `public` unless you need private egress/targets; scope
 the test to the endpoints you actually care about rather than the whole spec; tear
@@ -582,14 +579,14 @@ Plain scripts, no pytest, no AWS calls, no Bedrock calls:
 
 ```bash
 python3 builder/tests/test_spec_input.py        # 52 checks
-python3 builder/tests/test_builder.py           # 52 checks
-python3 builder/tests/test_script_builders.py   # 35 checks
+python3 builder/tests/test_builder.py           # 59 checks
+python3 builder/tests/test_script_builders.py   # 37 checks
 python3 builder/tests/test_taurus.py            # pass/fail, no count
 python3 test/test_agent_smoke.py                # 17 checks
-python3 test/test_tools.py                      # 42 checks
+python3 test/test_tools.py                      # 61 checks
 ```
 
-198 checks total. Each script prints `N passed, M failed` and exits non-zero on
+226 checks total. Each script prints `N passed, M failed` and exits non-zero on
 failure.
 
 | File | Proves |
@@ -599,7 +596,7 @@ failure.
 | `builder/tests/test_script_builders.py` | the k6 and Locust builders, generated scripts also executed |
 | `builder/tests/test_taurus.py` | Taurus — and therefore DLT — redistributes its own concurrency in proportion to `ThreadGroup.num_threads`, so per-endpoint load ratios survive the DLT hand-off |
 | `test/test_agent_smoke.py` | `agent.py` wiring: prompt loading, model resolution, clean imports |
-| `test/test_tools.py` | the `@tool` contract the model depends on, and the DLT safety gates (approval required, `saveOnly` on registration) without calling AWS |
+| `test/test_tools.py` | the `@tool` contract the model depends on, the DLT safety gates (approval required, `saveOnly` on registration), and the run-timing arithmetic a status read hands the model — including that a figure it cannot derive is left out rather than reported as zero. No AWS calls |
 
 ### Prerequisites
 

--- a/resilience/ai-load-test-generation-with-dlt/agent.py
+++ b/resilience/ai-load-test-generation-with-dlt/agent.py
@@ -42,7 +42,7 @@ def build_agent():
     """Construct the Strands agent. Tools are registered in tools/ (prompt 3);
     until then the agent runs conversation-only."""
     from strands import Agent
-    from strands.models import BedrockModel
+    from strands.models import BedrockModel, CacheConfig
 
     if not BEDROCK_REGION:
         raise RuntimeError(
@@ -54,6 +54,10 @@ def build_agent():
     model = BedrockModel(
         model_id=MODEL_PRIMARY,
         region_name=BEDROCK_REGION,
+        # A cycle here is a long tool loop, not a chat: the model is re-invoked
+        # once per tool call and every invocation resends the conversation so
+        # far. "auto" caches the history, not just the static prefix.
+        cache_config=CacheConfig(strategy="auto"),
     )
 
     tools = []

--- a/resilience/ai-load-test-generation-with-dlt/prompt/system_prompt.txt
+++ b/resilience/ai-load-test-generation-with-dlt/prompt/system_prompt.txt
@@ -90,6 +90,11 @@ engines later means rebuilding from the spec — never translating a script.
 - Writing against environment: prod is refused by the tools unless
   allow_prod_writes is set. Do not change environment to get around that.
 - Cancellation cannot be undone. Confirm the test is actually running first.
+- After run_scenario, do not wait for the run to finish. Confirm it started
+  (status running, no failed tasks), report the test_id and when to check back
+  using expected_seconds, and end the turn. A run outlasts a single request.
+- The test_id is the only handle that survives; the session is not. Name it in
+  every reply about a run, and say the results can be fetched with it later.
 - If the DLT region differs from the target's region, the round trip is included
   in the reported response times. Always say so when you report numbers.
 
@@ -107,6 +112,11 @@ engines later means rebuilding from the spec — never translating a script.
   K excluded, broken down by reason.
 - Provisioning takes about 90 seconds. Budget three minutes or more even for a
   short test.
+- Only ever quote elapsed and remaining time from the numbers a tool returned.
+  You have no clock, and the number of times you polled is not one — reporting a
+  healthy run as overdue is worse than saying you do not know how long it has
+  been. If a timing field is absent, say the run has not started or that its
+  duration was not reported.
 - Do not promise a DLT console link. discover_dlt_config returns console_url
   only for the ALB/CloudFront patterns; when headless is true it is null —
   report results with fetch_results and name the scenarios bucket instead of

--- a/resilience/ai-load-test-generation-with-dlt/prompt/system_prompt.txt
+++ b/resilience/ai-load-test-generation-with-dlt/prompt/system_prompt.txt
@@ -90,9 +90,18 @@ engines later means rebuilding from the spec — never translating a script.
 - Writing against environment: prod is refused by the tools unless
   allow_prod_writes is set. Do not change environment to get around that.
 - Cancellation cannot be undone. Confirm the test is actually running first.
-- After run_scenario, do not wait for the run to finish. Confirm it started
-  (status running, no failed tasks), report the test_id and when to check back
-  using expected_seconds, and end the turn. A run outlasts a single request.
+- After run_scenario, confirm the run started (a status past queued, no failed
+  tasks) before saying anything about it. Starting is not succeeding: tasks that
+  come up can still fail every request.
+- Then either wait or hand back, decided by remaining_seconds — never by polling
+  in a loop. At or under 600: wait, by passing wait_seconds to poll_test_status.
+  One call absorbs up to 240 seconds, so call it again while the run is unfinished
+  — three or four calls is normal and correct, not a loop. Then report the
+  results in that same turn. Above 600: do not wait. Give the test_id and when to
+  ask again, and end the turn.
+- Do not ask permission to wait and do not offer to wait as an alternative.
+  Handing back does not make the caller wait any less; it only adds a round trip.
+  Waiting nine minutes for an eight-minute run is the expected behaviour.
 - The test_id is the only handle that survives; the session is not. Name it in
   every reply about a run, and say the results can be fetched with it later.
 - If the DLT region differs from the target's region, the round trip is included

--- a/resilience/ai-load-test-generation-with-dlt/requirements.txt
+++ b/resilience/ai-load-test-generation-with-dlt/requirements.txt
@@ -1,5 +1,6 @@
 # Agent runtime
-strands-agents>=1.0
+# >=1.24: agent.py uses strands.models.CacheConfig, added in that release.
+strands-agents>=1.24
 bedrock-agentcore>=0.1
 boto3>=1.34
 python-dotenv>=1.0

--- a/resilience/ai-load-test-generation-with-dlt/test/test_tools.py
+++ b/resilience/ai-load-test-generation-with-dlt/test/test_tools.py
@@ -160,6 +160,65 @@ def main() -> int:
         check(not r["ok"] and "discover_dlt_config" in r["error"],
               f"{name} before discovery is refused")
 
+    print("run timing (no clock for the model to guess with)")
+    import datetime as dt
+    from tools.dlt_tools import _DLT_OVERHEAD_S, _parse_dlt_time, _run_timing
+
+    # DLT sends "2026-09-04 06:03:19" — no separator, no zone, value is UTC.
+    # fromisoformat would leave it naive and silently compare as local time.
+    t = _parse_dlt_time("2026-09-04 06:03:19")
+    check(t is not None and t.tzinfo == dt.timezone.utc and t.hour == 6,
+          "a DLT timestamp is parsed as UTC, not local time")
+    check(_parse_dlt_time(None) is None and _parse_dlt_time("nope") is None,
+          "an unparseable timestamp yields None rather than raising")
+
+    def body(started_ago: int, **over) -> dict:
+        started = dt.datetime.now(dt.timezone.utc) - dt.timedelta(
+            seconds=started_ago)
+        return {"startTime": started.strftime("%Y-%m-%d %H:%M:%S"),
+                "testScenario": {"execution": [{"ramp-up": "15s",
+                                                "hold-for": "60s"}]},
+                **over}
+
+    tm = _run_timing(body(30))
+    check(tm["expected_seconds"] == 15 + 60 + _DLT_OVERHEAD_S,
+          "expected_seconds is ramp-up + hold-for + measured overhead")
+    check(28 <= tm["elapsed_seconds"] <= 32,
+          f"elapsed_seconds comes from startTime (got {tm.get('elapsed_seconds')})")
+    check(tm["remaining_seconds"] == tm["expected_seconds"] - tm["elapsed_seconds"],
+          "remaining_seconds is the difference, not a guess")
+
+    # The load shape comes from the API response, never from _registered: a run
+    # longer than the idle timeout is polled by a fresh process with no state.
+    from tools import dlt_tools as dltm
+    check(not dltm._registered,
+          "run timing is derived without anything registered in this process")
+
+    over = _run_timing(body(9999))
+    check(over["remaining_seconds"] == 0,
+          "an overrun run clamps remaining to zero instead of going negative")
+
+    # Absent is not zero. A missing field must stay missing so the model has
+    # nothing to round off into a confident number.
+    check("elapsed_seconds" not in _run_timing({"status": "queued"}),
+          "a run that has not started reports no elapsed time at all")
+    no_shape = _run_timing({"startTime": "2026-09-04 06:03:19"})
+    check("elapsed_seconds" in no_shape and "expected_seconds" not in no_shape,
+          "elapsed is still reported when the load shape is unavailable")
+    check("expected_seconds" not in _run_timing(
+              body(30, testScenario={"execution": [{"ramp-up": "15x",
+                                                    "hold-for": "60s"}]})),
+          "an unparseable duration drops expected rather than assuming seconds")
+
+    done = _run_timing({"startTime": "2026-09-04 06:03:19",
+                        "endTime": "2026-09-04 06:06:58"})
+    check(done["elapsed_seconds"] == 219,
+          "a finished run measures to endTime, not to now")
+
+    check("Twenty to thirty seconds" not in poll_test_status.tool_spec[
+              "description"],
+          "the unfollowable polling-interval instruction is gone")
+
     print("multi-engine dispatch")
     r12 = call(validate_script, script_path="/nonexistent.xyz")
     check(not r12["ok"] and "unknown script type" in r12["error"],

--- a/resilience/ai-load-test-generation-with-dlt/test/test_tools.py
+++ b/resilience/ai-load-test-generation-with-dlt/test/test_tools.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -218,6 +219,62 @@ def main() -> int:
     check("Twenty to thirty seconds" not in poll_test_status.tool_spec[
               "description"],
           "the unfollowable polling-interval instruction is gone")
+
+    print("in-call waiting (a sleep costs no tokens; a re-read costs a round trip)")
+    # Stub the DLT call so the wait path runs without AWS or real time: the run
+    # reports `running` for the first few reads, then `complete`.
+    reads: list[float] = []
+    slept: list[float] = []
+
+    def fake_call(method, url, region, body=None):
+        reads.append(time.monotonic())
+        started = dt.datetime.now(dt.timezone.utc) - dt.timedelta(seconds=200)
+        return 200, {
+            "status": "complete" if len(reads) >= 3 else "running",
+            "taskFailureCount": 0,
+            "startTime": started.strftime("%Y-%m-%d %H:%M:%S"),
+            "testScenario": {"execution": [{"ramp-up": "15s", "hold-for": "60s"}]},
+        }
+
+    real_call, real_sleep, real_cfg = dltm._sigv4_call, time.sleep, dict(dltm._config)
+    dltm._sigv4_call = fake_call
+    time.sleep = lambda s: slept.append(s)
+    dltm._config = {"api_endpoint": "https://example.invalid", "api_region": "us-east-2"}
+    try:
+        r = call(poll_test_status, test_id="t")
+        check(r["ok"] and len(reads) == 1 and not slept,
+              "the default reads once and never sleeps (cancel needs a fast read)")
+
+        reads.clear(); slept.clear()
+        r = call(poll_test_status, test_id="t", wait_seconds=120)
+        check(r["status"] == "complete" and len(reads) == 3,
+              "waiting re-reads inside the one call until the run is terminal")
+        check(slept == [dltm._WAIT_GAP, dltm._WAIT_GAP],
+              f"it sleeps between reads, not between model calls (got {slept})")
+        check("waited_seconds" in r,
+              "the call reports how long it waited rather than leaving it implied")
+
+        # A run with more than _WAIT_OFFER_MAX left cannot be waited out inside
+        # one AgentCore request, so the wait path is declined -- but the read
+        # still succeeds, which is what keeps cancel_test reachable.
+        reads.clear(); slept.clear()
+        long_started = dt.datetime.now(dt.timezone.utc)
+
+        def long_run(method, url, region, body=None):
+            reads.append(time.monotonic())
+            return 200, {"status": "running", "taskFailureCount": 0,
+                         "startTime": long_started.strftime("%Y-%m-%d %H:%M:%S"),
+                         "testScenario": {"execution": [{"ramp-up": "30s",
+                                                         "hold-for": "40m"}]}}
+
+        dltm._sigv4_call = long_run
+        r = call(poll_test_status, test_id="t", wait_seconds=120)
+        check(r["ok"] and r["status"] == "running" and not slept,
+              "a run too long to wait out still returns its status, unrefused")
+        check(r["remaining_seconds"] > dltm._WAIT_OFFER_MAX and len(reads) == 1,
+              "no waiting happens when the run outlasts a single request")
+    finally:
+        dltm._sigv4_call, time.sleep, dltm._config = real_call, real_sleep, real_cfg
 
     print("multi-engine dispatch")
     r12 = call(validate_script, script_path="/nonexistent.xyz")

--- a/resilience/ai-load-test-generation-with-dlt/tools/dlt_tools.py
+++ b/resilience/ai-load-test-generation-with-dlt/tools/dlt_tools.py
@@ -17,8 +17,10 @@ documented shape returned three different 400s. Key facts baked in:
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
+import re
 from pathlib import Path
 
 import boto3
@@ -34,6 +36,67 @@ ROOT = Path(__file__).resolve().parent.parent
 # saveOnly flipped — per the verified API shape.
 _config: dict = {}
 _registered: dict[str, dict] = {}
+
+# Wall-clock overhead a run carries on top of ramp-up + hold-for: Fargate task
+# provisioning (~90s) plus teardown and result aggregation (~60s). Measured
+# across all 11 past runs of this deployment (endTime - startTime - load):
+# 113..165s, mean 150s, with no meaningful correlation to load length or
+# engine. 180 is the observed maximum rounded up on purpose — an optimistic
+# estimate is what makes the agent report a healthy run as "stuck".
+_DLT_OVERHEAD_S = 180
+
+_DURATION_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def _secs(value) -> int | None:
+    """Taurus duration ("15s", "2m") to seconds. None if unparseable."""
+    m = re.fullmatch(r"\s*(\d+)\s*([smhd]?)\s*", str(value))
+    if not m:
+        return None
+    return int(m.group(1)) * _DURATION_UNITS[m.group(2) or "s"]
+
+
+def _parse_dlt_time(value) -> dt.datetime | None:
+    """DLT timestamps arrive as "2026-09-04 06:03:19" — no separator, no zone,
+    but the value is UTC (cross-checked against the CloudWatch log line for the
+    same run). fromisoformat parses it too, yet leaves it tz-naive, which then
+    compares as local time; that is a 9-hour error for a KST developer and only
+    looks correct because the container runs in UTC. Tag it explicitly."""
+    try:
+        return dt.datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=dt.timezone.utc)
+    except (TypeError, ValueError):
+        return None
+
+
+def _run_timing(body: dict) -> dict:
+    """Elapsed/expected/remaining seconds for a run, derived only from the
+    GET /scenarios/{id} response — never from _registered. A load longer than
+    the AgentCore idle timeout outlives the microVM that registered it, so the
+    session that asks for results is often a fresh process with empty state.
+
+    Any field that cannot be derived is omitted rather than guessed: the point
+    of these numbers is to stop the model inventing them.
+    """
+    out: dict = {}
+    started = _parse_dlt_time(body.get("startTime"))
+    if started is None:
+        return out
+    ended = _parse_dlt_time(body.get("endTime"))
+    now = dt.datetime.now(dt.timezone.utc)
+    out["elapsed_seconds"] = int(((ended or now) - started).total_seconds())
+
+    execution = (body.get("testScenario") or {}).get("execution") or []
+    if isinstance(execution, list):
+        execution = execution[0] if execution else {}
+    if isinstance(execution, dict):
+        ramp_up, hold_for = _secs(execution.get("ramp-up")), _secs(
+            execution.get("hold-for"))
+        if ramp_up is not None and hold_for is not None:
+            out["expected_seconds"] = ramp_up + hold_for + _DLT_OVERHEAD_S
+            out["remaining_seconds"] = max(
+                0, out["expected_seconds"] - out["elapsed_seconds"])
+    return out
 
 
 def _ok(**fields) -> str:
@@ -340,21 +403,30 @@ def run_scenario(test_id: str, approval_summary: str) -> str:
 
 @tool
 def poll_test_status(test_id: str) -> str:
-    """Read a test's status once. Never block and poll — one read per call.
+    """Read a test's status once. One read per call — this never blocks.
 
     The states go queued, provisioning (about 90s), running, complete. Even a
     40-second load run takes over three minutes end to end (3m16s measured).
-    Account for that overhead before telling anyone it is nearly done. Twenty to
-    thirty seconds is a sensible gap between reads.
+    Account for that overhead before telling anyone it is nearly done.
+
+    You have no clock, so quote elapsed_seconds and remaining_seconds and never
+    estimate the passage of time from how many times you have called this. If
+    remaining_seconds is above zero the run is not late, however many reads it
+    took to get here. Do not wait for completion by calling this repeatedly:
+    say what the numbers say, tell the caller when to ask again, and end the
+    turn. Reading again in the same turn cannot make the run finish sooner.
 
     Args:
         test_id: the scenario ID to read
 
     Returns:
         JSON: {ok, status, task_failure_count, complete_tasks, start_time,
-        end_time}. If the status is complete but task_failure_count > 0, do not
-        report completion — some tasks died, so the metrics do not reflect the
-        load that was planned.
+        end_time, elapsed_seconds, expected_seconds, remaining_seconds}. The
+        three timing fields are omitted when the run has not started or the API
+        did not report its load shape — an omitted field is not a zero, and it
+        is never something to fill in by guessing. If the status is complete but
+        task_failure_count > 0, do not report completion — some tasks died, so
+        the metrics do not reflect the load that was planned.
     """
     if not _config:
         return _err("run discover_dlt_config first")
@@ -367,7 +439,8 @@ def poll_test_status(test_id: str) -> str:
                task_failure_count=body.get("taskFailureCount", 0),
                complete_tasks=body.get("completeTasks"),
                start_time=body.get("startTime"),
-               end_time=body.get("endTime"))
+               end_time=body.get("endTime"),
+               **_run_timing(body if isinstance(body, dict) else {}))
 
 
 @tool

--- a/resilience/ai-load-test-generation-with-dlt/tools/dlt_tools.py
+++ b/resilience/ai-load-test-generation-with-dlt/tools/dlt_tools.py
@@ -21,6 +21,7 @@ import datetime as dt
 import json
 import os
 import re
+import time
 from pathlib import Path
 
 import boto3
@@ -43,7 +44,31 @@ _registered: dict[str, dict] = {}
 # 113..165s, mean 150s, with no meaningful correlation to load length or
 # engine. 180 is the observed maximum rounded up on purpose — an optimistic
 # estimate is what makes the agent report a healthy run as "stuck".
+#
+# Those runs were all one Fargate task in one Region, so a deployment placing
+# many tasks, or a different Region, can overrun this. Underestimating is safe
+# by construction: status always comes from the API, so the run still reports
+# itself as running and the caller is simply asked again — the estimate only
+# decides how long a wait may last and when to suggest checking back, never
+# whether the run is healthy. A deployment that consistently overruns can read
+# its own figure off the `history` in a GET /scenarios/{id} response, which
+# carries startTime, endTime and the execution block for every past run.
 _DLT_OVERHEAD_S = 180
+
+# States a run does not leave, so waiting past one is pointless.
+_TERMINAL_STATES = ("complete", "cancelled", "failed")
+
+# poll_test_status may wait inside the call instead of returning and being asked
+# again, because a model round trip costs ~20k tokens and passes no more time
+# than one blocking call does. The ceiling is per call: the model can call again
+# if the run is still going, and each call re-derives its budget from the run's
+# own remaining time. _WAIT_OFFER_MAX keeps a long run out of the wait path
+# entirely — AgentCore kills a synchronous request at 15 minutes, so a 30-minute
+# load has to be collected in a later turn no matter what.
+_WAIT_CAP = 240        # max seconds one call may block
+_WAIT_GAP = 15         # seconds between in-call DLT reads (free; not model calls)
+_WAIT_GRACE = 30       # slack past expected completion, for overhead variance
+_WAIT_OFFER_MAX = 600  # refuse to wait when the run has longer than this left
 
 _DURATION_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
 
@@ -402,8 +427,8 @@ def run_scenario(test_id: str, approval_summary: str) -> str:
 
 
 @tool
-def poll_test_status(test_id: str) -> str:
-    """Read a test's status once. One read per call — this never blocks.
+def poll_test_status(test_id: str, wait_seconds: int = 0) -> str:
+    """Read a test's status, optionally waiting inside this call for it to end.
 
     The states go queued, provisioning (about 90s), running, complete. Even a
     40-second load run takes over three minutes end to end (3m16s measured).
@@ -412,35 +437,86 @@ def poll_test_status(test_id: str) -> str:
     You have no clock, so quote elapsed_seconds and remaining_seconds and never
     estimate the passage of time from how many times you have called this. If
     remaining_seconds is above zero the run is not late, however many reads it
-    took to get here. Do not wait for completion by calling this repeatedly:
-    say what the numbers say, tell the caller when to ask again, and end the
-    turn. Reading again in the same turn cannot make the run finish sooner.
+    took to get here. Reaching zero is not a fault either — it is an estimate
+    running out, and the expected overhead is calibrated on one deployment, so
+    heavier task counts legitimately exceed it. Status is the only authority on
+    whether a run is healthy: while it says running, say so and ask the caller
+    back, and never volunteer cancelling on the strength of the estimate alone.
+    Never wait by calling this repeatedly — that costs a full model round trip
+    per read and passes no more time than one call does. Use wait_seconds
+    instead, or say what the numbers say and end the turn.
 
     Args:
         test_id: the scenario ID to read
+        wait_seconds: how long this call may wait for the run to end, in
+            seconds. 0 (the default) reads once and returns immediately — use
+            that when you need the status right now, such as before cancelling,
+            or when you are reporting progress and ending the turn. Pass a value
+            whenever the caller is waiting on the result and remaining_seconds is
+            600 or less; the wait ends the moment the run does. One call absorbs
+            at most 240 seconds, so calling again while the run is unfinished is
+            the intended way to cover a longer wait — the total can only ever
+            reach the run's own remaining time. Waiting is declined outright
+            above 600 seconds remaining, because a synchronous AgentCore request
+            dies at 15 minutes; that run has to be collected in a later turn.
 
     Returns:
         JSON: {ok, status, task_failure_count, complete_tasks, start_time,
-        end_time, elapsed_seconds, expected_seconds, remaining_seconds}. The
-        three timing fields are omitted when the run has not started or the API
-        did not report its load shape — an omitted field is not a zero, and it
-        is never something to fill in by guessing. If the status is complete but
-        task_failure_count > 0, do not report completion — some tasks died, so
-        the metrics do not reflect the load that was planned.
+        end_time, elapsed_seconds, expected_seconds, remaining_seconds,
+        waited_seconds}. The timing fields are omitted when the run has not
+        started or the API did not report its load shape — an omitted field is
+        not a zero, and it is never something to fill in by guessing. If the
+        status is complete but task_failure_count > 0, do not report completion
+        — some tasks died, so the metrics do not reflect the load that was
+        planned.
     """
     if not _config:
         return _err("run discover_dlt_config first")
-    code, body = _sigv4_call(
-        "GET", f"{_config['api_endpoint']}/scenarios/{test_id}",
-        _config["api_region"])
+
+    url = f"{_config['api_endpoint']}/scenarios/{test_id}"
+
+    def read() -> tuple[int, dict | str, dict]:
+        code, body = _sigv4_call("GET", url, _config["api_region"])
+        return code, body, _run_timing(body if isinstance(body, dict) else {})
+
+    code, body, timing = read()
     if code != 200:
         return _err(f"status query failed ({code})", response=body)
+
+    # How long this call may block is derived from the run itself rather than
+    # from a counter of previous calls. A counter would keep accumulating across
+    # turns and eventually refuse a legitimate check; the run's own remaining
+    # time cannot, and it bounds total waiting to roughly the time the run has
+    # left however many times this is called. Reads themselves are never
+    # refused: cancel_test needs one to confirm a runaway run is live.
+    remaining = timing.get("remaining_seconds")
+    budget = 0.0
+    if wait_seconds > 0 and remaining is not None and remaining <= _WAIT_OFFER_MAX:
+        budget = min(float(wait_seconds), float(_WAIT_CAP), remaining + _WAIT_GRACE)
+
+    waited = 0.0
+    if budget > 0:
+        deadline = time.monotonic() + budget
+        # Polling DLT from in here is an HTTPS GET, not a model round trip, so
+        # the gap costs nothing and only bounds how stale the answer can be.
+        while body.get("status") not in _TERMINAL_STATES:
+            left = deadline - time.monotonic()
+            if left <= 0:
+                break
+            time.sleep(min(float(_WAIT_GAP), left))
+            code, next_body, next_timing = read()
+            if code != 200:
+                break  # keep the last good read rather than failing the call
+            body, timing = next_body, next_timing
+        waited = round(time.monotonic() - (deadline - budget), 1)
+
     return _ok(status=body.get("status"),
                task_failure_count=body.get("taskFailureCount", 0),
                complete_tasks=body.get("completeTasks"),
                start_time=body.get("startTime"),
                end_time=body.get("endTime"),
-               **_run_timing(body if isinstance(body, dict) else {}))
+               waited_seconds=waited,
+               **timing)
 
 
 @tool


### PR DESCRIPTION
Four commits to `resilience/ai-load-test-generation-with-dlt/`, all about the
window between "the load test started" and "here are the results". No new tools,
no changed tool signature except one optional argument, no safety gate touched.

| | before | after |
|---|---|---|
| Bedrock inference per cycle | $17.08 | **$0.63** (Sonnet 5: $0.32) |
| Model round trips per cycle | 108 | 20 |
| `poll_test_status` calls | **29** | 2 |
| Elapsed time reported to the user | estimated from poll count | derived from the API's `startTime` |

## Why

**Polling was the expensive part.** Once `run_scenario` starts a DLT run, the run
takes minutes — provisioning alone is about 90 seconds — and the agent has to keep
checking `GET /scenarios/{id}` until it reports `complete` before it can fetch and
interpret the results. That check went through `poll_test_status`, and one
`poll_test_status` is not an HTTPS GET: it is a model round trip, and every round
trip resends the conversation so far (~28k tokens by that point in a cycle). One
measured cycle made 29 of them in the first 66 seconds — roughly 800k tokens, more
than a quarter of the cycle's input, spent before a single request reached the
target. The waiting is now done inside the tool, where a sleep costs nothing and
re-reading DLT is a plain HTTPS GET: 240 seconds for one round trip instead of
dozens.

**The agent had no clock.** `poll_test_status` returned `startTime` but nothing to
compare it against, so the elapsed times it reported to the user had no source —
30 seconds of polling described as a spent five-minute budget, and 32 seconds
after a task went RUNNING described as "stuck well past the normal 90 seconds".
The status values were correct, which is what made the numbers believable. It now
returns elapsed, expected and remaining seconds, derived from the API's own
timestamps.

**Nothing cached.** A cycle is a long tool loop, not a chat: the model is
re-invoked once per tool call and each invocation resends the conversation so far.
The static prefix is a small fraction of that; accumulated tool output is the
rest, so caching the prefix alone would leave most of it uncached.

## How

- **`CacheConfig(strategy="auto")`** caches the history, not just the prefix. This
  is the single largest saving: $17.08 → $2.32.
- **`poll_test_status` returns the numbers** — `elapsed_seconds`,
  `expected_seconds`, `remaining_seconds` — derived only from the
  `GET /scenarios/{id}` response, never from in-process state, so a run that
  outlives its session can still be picked up by test id alone. A figure that
  cannot be derived is omitted rather than reported as zero.
- **`poll_test_status(wait_seconds=...)` waits inside the call**, re-reading DLT
  every 15s. 240s per call, never beyond the run's own remaining time, and
  declined outright above 600s remaining because a synchronous AgentCore request
  dies at 15 minutes — that run is collected in a later turn instead. How long a
  call may block is derived from the run's remaining time rather than a counter of
  previous calls, which would accumulate across turns and eventually refuse a
  legitimate check.
- **The thresholds are numbers, not adjectives** — in the prompt and the tool
  description, not only in the code, since the model cannot see the constants.

## Verification

Five end-to-end cycles against a deployed runtime (spec → endpoint selection →
JMeter build → 1-VU smoke → DLT register → approval → load → interpretation):

| configuration | model | load | cycle | `poll_test_status` | gaps between reads |
|---|---|---|---|---|---|
| before (`upstream/main`) | Opus | 5 VU / 1 min | $17.08 | 29 | 1-2s |
| after | Opus | 5 VU / 1 min | **$0.63** | 2 | 123s, 97s |

Two more runs check that this is not specific to one load shape or one model. At
10 VU / 5 min the same configuration also came to $0.63 — cost does not move with
the load's duration, because the waiting happens in a tool call rather than in the
model loop — with two reads 243s and 242s apart. Sonnet 5 on that shape held every
safety gate, waited identically (244s and 236s), and came to $0.32.

Every run: 0 failed samples, 0 task failures, setup correlation once per VU, the
traffic split matching the thread allocation.

Token figures come from CloudWatch `AWS/Bedrock` scoped to each run's window, and
costs from the billed usage types in Cost Explorer rather than list price.

Unit tests: 208 → 226 checks, all passing. The new ones cover the timing
arithmetic (including that an underivable figure stays absent), UTC parsing of
DLT's zone-less timestamps, and the wait path with the DLT call and `sleep`
stubbed — no AWS calls.

## Docs

The README described the old behaviour and now matches the new one. The
walkthrough's "Do not block-poll", "ask for a single read" and two `sleep && say`
turns are gone; results now arrive in the turn that starts the run, five turns
down to three, with the figures taken from a verified run.

Those instructions existed for a real reason — the README said polling inside one
turn "just burns model tokens waiting", which was correct. The remedy was to hand
the waiting to the human, who ran `sleep` in their own shell. The agent obeyed:
it never blocked inside the tool, it called the tool 29 times instead, waiting the
same 66 seconds for 800k tokens rather than none. Blocking was not the problem;
where the blocking happened was. So the waiting moved into the tool rather than
being forbidden.

The README also states where waiting stops and the test id takes over, and the
test counts are corrected.

The expected-overhead constant (180s) is calibrated on one deployment of one task
in one Region, so a heavier task count can legitimately exceed it. Both the
constant and the tool description say why underestimating is safe: status always
comes from the API, so the run keeps reporting itself as running and the caller is
simply asked again. The estimate bounds a wait and picks a check-back time; it is
never evidence that a run is unhealthy.
