### PR TITLE
docs+ci: demo validation.yaml contract + demo-cdk-validation workflow

### DIFF
--- a/.github/workflows/demo-cdk-validation.yml
+++ b/.github/workflows/demo-cdk-validation.yml
@@ -1,0 +1,97 @@
+# Demo CDK validation workflow.
+#
+# THIS FILE IS DELIVERED INTO THE DEMOS REPO, not run from this GitLab repo. Its final home is
+#   aws-samples/sample-aws-genai-ops-demos : .github/workflows/demo-cdk-validation.yml
+# It is authored/versioned here first for review. (It lives under platform/github-workflow/ so
+# this repo's own GitLab CI never treats it as a pipeline of its own.)
+#
+# What it does: on manual trigger, deploy -> verify -> destroy one demo's CDK in the
+# genai-ops-demos AWS account, using OIDC (no long-lived keys, no self-hosted runner). Pass/fail
+# is the native Actions result. See .kiro/specs/demo-cdk-testing/ in the internal infra repo.
+#
+# Safe-authoring notes (per "Use GitHub Actions Safely"):
+#   - workflow_dispatch only (maintainer-triggered); NO pull_request_target.
+#   - runs under the reviewer-gated `demo-validation` environment (approval required).
+#   - untrusted inputs (demo, region) passed via env vars, never interpolated into run: scripts.
+#   - only first-party actions (actions/checkout, aws-actions/configure-aws-credentials).
+#   - minimal permissions: id-token: write (OIDC), contents: read (checkout).
+
+name: Demo CDK validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      demo_path:
+        description: "Demo folder path to validate, e.g. 'security/ai-incident-response-playbook-builder'. Its validation.yaml defines how it's deployed/verified/destroyed."
+        required: true
+        type: string
+      ref:
+        description: "Git ref (branch/tag/SHA) to check out and validate. Defaults to the default branch — set a PR branch to validate a proposed demo."
+        required: false
+        type: string
+
+permissions:
+  id-token: write   # required to mint the OIDC token
+  contents: read    # required for actions/checkout
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    # Reviewer-gated environment: a maintainer must approve before this job proceeds, and the
+    # OIDC trust policy is pinned to this environment.
+    environment: demo-validation
+    steps:
+      - name: Check out the demos repo
+        uses: actions/checkout@v4
+        with:
+          # Defaults to the default branch when `ref` is empty. Set a PR branch to validate a
+          # proposed demo before merge; leave empty to validate an existing demo on main.
+          ref: ${{ inputs.ref }}
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # Role deployed by the internal infra repo's platform/ app (GithubDemoValidationRole).
+          # Its ARN is the stack output GithubDemoValidationRoleArn.
+          role-to-assume: ${{ vars.DEMO_VALIDATION_ROLE_ARN }}
+          # This is only the default region for the STS call / SDK. The demo runner overrides
+          # AWS_REGION per-demo (e.g. eu-west-1 for the VPN demo), and the OIDC role can assume
+          # the CDK bootstrap roles in every bootstrapped region, so cross-region deploys work.
+          aws-region: us-west-2
+          role-session-name: demo-cdk-validation
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install AWS CDK CLI
+        run: npm install -g aws-cdk@2
+
+      # The deploy/verify/destroy runner (genai_ops_common) lives in a PRIVATE internal GitLab
+      # repo a public runner can't pip-install from. Instead the infra repo's platform/ app
+      # publishes it to a PRIVATE S3 bucket; this job (already authenticated via the OIDC role,
+      # which has read on that bucket) fetches it. Single source of truth, nothing public, no
+      # copy committed here. DEMO_RUNNER_BUCKET is the DemoRunnerBucketName stack output.
+      - name: Fetch the demo runner from the private bucket
+        env:
+          RUNNER_BUCKET: ${{ vars.DEMO_RUNNER_BUCKET }}
+          RUNNER_HOME: ${{ runner.temp }}/demo-runner
+        run: |
+          mkdir -p "$RUNNER_HOME/genai_ops_common"
+          aws s3 cp "s3://${RUNNER_BUCKET}/demo-runner/genai_ops_common" \
+            "$RUNNER_HOME/genai_ops_common" --recursive
+          pip install pyyaml
+
+      - name: Deploy -> verify -> destroy the demo
+        env:
+          # Untrusted input passed via env var, never interpolated into the shell (injection-safe).
+          DEMO_PATH: ${{ inputs.demo_path }}
+          RUNNER_HOME: ${{ runner.temp }}/demo-runner
+          REPO_ROOT: ${{ github.workspace }}
+        run: |
+          # Run the runner from where the package was fetched, but point --repo-root at the
+          # checked-out demos repo so it can read <demo>/validation.yaml and run the demo's
+          # scripts by relative path.
+          cd "$RUNNER_HOME"
+          python -m genai_ops_common.demo_runner --path "$DEMO_PATH" --repo-root "$REPO_ROOT"

--- a/.kiro/steering/contributor-guide.md
+++ b/.kiro/steering/contributor-guide.md
@@ -159,6 +159,9 @@ Actions workflow with a demo's folder path. The workflow runs on GitHub-hosted r
 using OIDC, reads that demo's `validation.yaml`, and drives an end-to-end
 **deploy → verify → destroy** cycle against a test AWS account.
 
+A starter template is available at `shared/templates/validation.yaml.example` — copy it
+into your demo folder and edit the values.
+
 ### Schema
 
 | Key | Type | Required | Default | Description |

--- a/.kiro/steering/contributor-guide.md
+++ b/.kiro/steering/contributor-guide.md
@@ -148,6 +148,65 @@ The CI workflow will flag PRs using `.no-deploy` with a `deploy-exempt` label fo
 
 ---
 
+## Demo Validation (`validation.yaml`)
+
+Every deployable demo SHOULD ship a `validation.yaml` at its **demo root**. This file
+teaches the internal demo-validation system how to deploy, verify, and destroy the demo
+in a test AWS account. Demos exempted via `.no-deploy` do not need one.
+
+**How it's used:** a maintainer manually triggers the `demo-cdk-validation.yml` GitHub
+Actions workflow with a demo's folder path. The workflow runs on GitHub-hosted runners
+using OIDC, reads that demo's `validation.yaml`, and drives an end-to-end
+**deploy → verify → destroy** cycle against a test AWS account.
+
+### Schema
+
+| Key | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `deploy_command` | list | ✅ | — | The demo's own deploy command argv, run from the demo folder (e.g. `["./deploy-all.sh"]`) |
+| `destroy_command` | list | ❌ | `["npx", "-y", "cdk", "destroy", "--force", "--no-cli-pager"]` | Teardown command argv |
+| `destroy_subdir` | string | ❌ | `"infrastructure/cdk"` | Subdirectory (under the demo folder) to run the destroy command from |
+| `stacks` | list | ✅ (for deterministic verify) | — | CloudFormation stack name(s) to confirm deployed, then confirm destroyed. Use the region-suffixed stack IDs already required elsewhere in this guide |
+| `region` | string | ❌ | ambient region | Region the demo deploys to |
+| `verify` | string | ❌ | `"deterministic"` | `"deterministic"` or `"agent"` — see below |
+| `notes` | string | ❌ | — | Gotchas for maintainers (e.g. "needs Bedrock Claude access enabled") |
+
+### Choosing a `verify` mode
+
+- **`deterministic`** — use when whether the demo "really works" depends on something
+  CI cannot drive itself (a manually enabled Bedrock model, a Slack webhook, DevOps Agent
+  registration, AWS Transform). The only reliable signal here is that the demo **deployed
+  and destroyed cleanly** — the stack(s) in `stacks` reach `CREATE_COMPLETE` and are later
+  confirmed gone.
+- **`agent`** — use for self-contained demos where functional success is checkable, but
+  too demo-specific to hardcode into the validation system. An agent reads the demo's
+  README and performs functional checks beyond "did the stack deploy."
+
+  > **Note:** `agent` verification is a planned capability. Until it exists, `verify: agent`
+  > falls back to the same deterministic deploy/destroy check as above.
+
+### Example
+
+`security/ai-incident-response-playbook-builder/validation.yaml`:
+
+```yaml
+deploy_command: ["./build-playbooks.sh"]
+stacks:
+  - "PlaybookBuilderStack-<region>"
+verify: deterministic
+notes: "Needs Bedrock Claude model access enabled in the test account before running."
+```
+
+### Teardown is first-class
+
+Cleanup is not optional. A demo that deploys successfully but **cannot be cleanly
+destroyed is treated as a failed validation** — not a partial pass. Before shipping a
+`validation.yaml`, confirm that `cdk destroy` (or your custom `destroy_command`) actually
+removes every resource the deploy created. A demo that leaves orphaned resources behind
+fails validation even if the deploy itself succeeded.
+
+---
+
 ## Implementation Patterns
 
 ### Region Detection

--- a/security/ai-incident-response-playbook-builder/validation.yaml
+++ b/security/ai-incident-response-playbook-builder/validation.yaml
@@ -1,0 +1,29 @@
+# validation.yaml — tells the demo-cdk-validation workflow how to deploy, verify, and tear
+# down this demo. See .kiro/steering/contributor-guide.md ("Demo Validation (validation.yaml)")
+# for the full schema.
+
+# The demo's OWN deploy command (argv), run from the demo folder.
+deploy_command: ["./build-playbooks.sh"]
+
+# Teardown command (argv), run from destroy_subdir (below).
+destroy_command: ["npx", "-y", "cdk", "destroy", "--force", "--no-cli-pager"]
+
+# Subdir under the demo folder to run destroy from.
+destroy_subdir: "infrastructure/cdk"
+
+# CloudFormation stack to confirm deployed and later confirm destroyed.
+# Matches infrastructure/cdk/app.py: PlaybookBuilderStack-{region}.
+stacks: ["PlaybookBuilderStack-us-west-2"]
+
+# Region the demo deploys to.
+region: "us-west-2"
+
+# deterministic: this demo's generation phase depends on Bedrock Claude model access being
+# manually enabled in the account, which CI can't drive. The reliable signal is that the
+# stack (one S3 bucket) deploys and destroys cleanly.
+verify: "deterministic"
+
+notes: >
+  Deploys one S3 bucket via CDK; build-playbooks.sh then runs discovery + Bedrock generation
+  locally. Needs Claude model access enabled in the account for the generation phase. Zero
+  required args.

--- a/shared/templates/validation.yaml.example
+++ b/shared/templates/validation.yaml.example
@@ -1,0 +1,45 @@
+# Example validation.yaml — a demo ships this in its OWN folder in the public demos repo, e.g.
+#   security/ai-incident-response-playbook-builder/validation.yaml
+#
+# The demo-validation workflow reads <demo-path>/validation.yaml to learn how to deploy, verify,
+# and tear the demo down. Keeping it in the demo's folder means the validation contract lives
+# with the demo (author sets it at contribution time), scales to every demo without a central
+# list, and lets a maintainer validate any demo just by pointing the workflow at its path.
+#
+# To use: copy this file to <your-demo>/validation.yaml and edit the values. See
+# .kiro/steering/contributor-guide.md ("Demo Validation (validation.yaml)") for the full schema.
+#
+# This example matches the reference demo (ai-incident-response-playbook-builder).
+
+# The demo's OWN deploy command (argv), run from the demo folder. REQUIRED.
+# We drive the demo's script rather than re-implementing its deployment.
+deploy_command: ["./build-playbooks.sh"]
+
+# Teardown command (argv), run from destroy_subdir (below).
+# Default if omitted: ["npx", "-y", "cdk", "destroy", "--force", "--no-cli-pager"]
+destroy_command: ["npx", "-y", "cdk", "destroy", "--force", "--no-cli-pager"]
+
+# Subdir under the demo folder to run destroy from. Default: "infrastructure/cdk".
+destroy_subdir: "infrastructure/cdk"
+
+# CloudFormation stack name(s) to confirm deployed (verify) and confirm gone (destroy).
+# REQUIRED for the deterministic verify strategy. Use the region-suffixed stack ID your
+# CDK app already produces (see contributor-guide.md "CDK Stack Naming").
+stacks: ["PlaybookBuilderStack-us-west-2"]
+
+# Region the demo deploys to. Default: the workflow's default region (us-west-2).
+region: "us-west-2"
+
+# Verify strategy:
+#   deterministic (default) — check the stack(s) reached *_COMPLETE. Use this when the demo's
+#     "does it really work" depends on external things CI can't drive (e.g. a manually-enabled
+#     Bedrock model, a Slack webhook, DevOps Agent registration).
+#   agent — hand off to the backend verification agent for functional checks (Phase 2; falls
+#     back to deterministic until that exists).
+verify: "deterministic"
+
+# Freeform notes / gotchas for maintainers.
+notes: >
+  Deploys one S3 bucket via CDK; build-playbooks.sh then runs discovery + Bedrock generation
+  locally. Needs Claude model access enabled in the account for the generation phase. Zero
+  required args.


### PR DESCRIPTION
## Summary
- Documents the `validation.yaml` contract in `contributor-guide.md` — every deployable demo SHOULD ship one at its root so the internal demo-validation system knows how to deploy/verify/destroy it.
- Adds `.github/workflows/demo-cdk-validation.yml`: a maintainer-triggered (`workflow_dispatch`), OIDC-authenticated workflow that reads a demo's `validation.yaml` and runs an end-to-end deploy → verify → destroy cycle in a test AWS account.
- Adds `shared/templates/validation.yaml.example` as a copyable starter template, linked from the contributor guide.
- Adds a real `validation.yaml` for the reference demo, `security/ai-incident-response-playbook-builder`.

## Details
- Schema: `deploy_command` (required), `destroy_command`/`destroy_subdir` (optional, sane defaults), `stacks` (required for deterministic verify), `region`, `verify` (`deterministic` default, `agent` planned), `notes`.
- Teardown is documented as first-class: a demo that deploys but can't be cleanly destroyed is a failed validation.
- The workflow runs under a reviewer-gated `demo-validation` environment, uses OIDC only (no long-lived keys, no self-hosted runner), and passes untrusted inputs via env vars (never interpolated into shell).

## Testing
- Manually verified the reference demo's existing deploy script/CDK app against the new `validation.yaml` (stack name, deploy command, solution-adoption tracking already correct — no demo code changed).
- Not yet run against a live test account end-to-end — this PR lands the contract + workflow; first live run should follow.

## Notes for reviewers
- `.github/` and `.kiro/` changes are flagged by `governance-guard.yml` per policy — I'm a maintainer and reviewed this myself, but flagging per process.
- The workflow depends on repo/environment config that doesn't exist yet and isn't part of this PR: the `demo-validation` GitHub environment (with required reviewers) and the `DEMO_VALIDATION_ROLE_ARN` / `DEMO_RUNNER_BUCKET` variables.