### PR TITLE
Fix silent pip failure in Python CDK demo validation

### DIFF
--- a/.kiro/steering/contributor-guide.md
+++ b/.kiro/steering/contributor-guide.md
@@ -167,10 +167,12 @@ into your demo folder and edit the values.
 | Key | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `deploy_command` | list | ✅ | — | The demo's own deploy command argv, run from the demo folder (e.g. `["./deploy-all.sh"]`) |
+| `setup_commands` | list of lists | ❌ | — | Command argv(s) run from the demo folder **before** `deploy_command`, to establish prerequisites the deploy path can't be trusted to establish itself (see "Python CDK demos" below) |
 | `destroy_command` | list | ❌ | `["npx", "-y", "cdk", "destroy", "--force", "--no-cli-pager"]` | Teardown command argv |
 | `destroy_subdir` | string | ❌ | `"infrastructure/cdk"` | Subdirectory (under the demo folder) to run the destroy command from |
 | `stacks` | list | ✅ (for deterministic verify) | — | CloudFormation stack name(s) to confirm deployed, then confirm destroyed. Use the region-suffixed stack IDs already required elsewhere in this guide |
 | `region` | string | ❌ | ambient region | Region the demo deploys to |
+| `pythonpath_repo_root` | bool | ❌ | `false` | Set `true` when the CDK `app.py` imports the repo's `shared/` package, so the direct-`cdk destroy` path (which bypasses the shared scripts) can still import `shared` — see "Python CDK demos" below |
 | `verify` | string | ❌ | `"deterministic"` | `"deterministic"` or `"agent"` — see below |
 | `notes` | string | ❌ | — | Gotchas for maintainers (e.g. "needs Bedrock Claude access enabled") |
 
@@ -187,6 +189,49 @@ into your demo folder and edit the values.
 
   > **Note:** `agent` verification is a planned capability. Until it exists, `verify: agent`
   > falls back to the same deterministic deploy/destroy check as above.
+
+### Python CDK demos: declare your own deps (failure-derived)
+
+If a demo deploys via the shared `shared/scripts/deploy-cdk.sh`, add a `setup_commands`
+entry installing the demo's own `infrastructure/cdk/requirements.txt` **before**
+`deploy_command` runs:
+
+```yaml
+setup_commands:
+  - ["pip", "install", "-r", "infrastructure/cdk/requirements.txt"]
+```
+
+This is **not** redundant with the shared script's own install. That script installs the
+Python CDK deps under `set +e` with both attempts silenced:
+
+```bash
+set +e
+pip3 install -r requirements.txt -q 2>/dev/null
+if [ $? -ne 0 ]; then
+    pip3 install -r requirements.txt -q --break-system-packages 2>/dev/null
+fi
+set -e
+...
+echo -e "...OK: Python CDK dependencies installed"
+```
+
+Because both `pip3` attempts pipe stderr to `/dev/null` and the block runs under `set +e`,
+a failed install is invisible and non-fatal — the script prints `OK: Python CDK
+dependencies installed` and proceeds to `cdk deploy` regardless. On a clean runner that
+leaves `aws_cdk` uninstalled, and `cdk deploy` (which synths via `python3 app.py`) then
+fails with `ModuleNotFoundError: No module named 'aws_cdk'`.
+
+This is **failure-derived knowledge**: you cannot infer it by reading the demo, because the
+script reports success even when the install failed. It surfaces only by running the deploy
+on a clean runner. So the dependency must be **declared** in `setup_commands` rather than
+assumed to be handled by the deploy path.
+
+Relatedly, set `pythonpath_repo_root: true` for any demo whose CDK `app.py` imports the
+repo's `shared/` package (e.g. `from shared.utils import get_region`). The deploy path is
+fine — `deploy-cdk.sh` exports `PYTHONPATH="$REPO_ROOT"` before `cdk deploy` — but the
+`destroy` step runs `npx cdk destroy` directly, bypassing the shared scripts, and re-synths
+`app.py` with no `PYTHONPATH`; without the flag that import fails with `ModuleNotFoundError:
+No module named 'shared'` and destroy fails even though deploy succeeded.
 
 ### Example
 

--- a/security/ai-incident-response-playbook-builder/validation.yaml
+++ b/security/ai-incident-response-playbook-builder/validation.yaml
@@ -10,6 +10,24 @@
 # Bedrock call fails deploy_command itself, independent of the verify step below.
 deploy_command: ["./build-playbooks.sh"]
 
+# Install this demo's OWN CDK deps explicitly and loudly BEFORE deploy_command runs.
+# This is NOT redundant with the shared shared/scripts/deploy-cdk.sh (which build-playbooks.sh
+# calls): that script's Python install is silent and non-fatal. It runs, under `set +e`:
+#     pip3 install -r requirements.txt -q 2>/dev/null
+#     if [ $? -ne 0 ]; then
+#         pip3 install -r requirements.txt -q --break-system-packages 2>/dev/null
+#     fi
+#     set -e
+#     ...
+#     echo -e "...OK: Python CDK dependencies installed"
+# Both pip attempts pipe stderr to /dev/null and the block is under `set +e`, so a failed
+# install is invisible and non-fatal -- the script prints "OK" and proceeds to `cdk deploy`
+# anyway. On a clean runner that leaves aws_cdk uninstalled and `cdk deploy` (which synths via
+# `python3 app.py`) then dies with `ModuleNotFoundError: No module named 'aws_cdk'`. Declaring
+# the install here guarantees aws_cdk is importable regardless of the shared script's outcome.
+setup_commands:
+  - ["pip", "install", "-r", "infrastructure/cdk/requirements.txt"]
+
 # Runs `npx cdk destroy` directly, bypassing build-playbooks.sh and shared/scripts/deploy-cdk.sh
 # entirely -- see pythonpath_repo_root below for why that matters here.
 destroy_command: ["npx", "-y", "cdk", "destroy", "--force", "--no-cli-pager"]


### PR DESCRIPTION
## Summary

Fixes a real, runner-only failure mode for Python CDK demos validated via the shared `shared/scripts/deploy-cdk.sh`.

That script installs the Python CDK deps under `set +e` with both pip attempts silenced:

```bash
set +e
pip3 install -r requirements.txt -q 2>/dev/null
if [ $? -ne 0 ]; then
    pip3 install -r requirements.txt -q --break-system-packages 2>/dev/null
fi
set -e
...
echo -e "...OK: Python CDK dependencies installed"
```

Because both attempts pipe stderr to `/dev/null` and run under `set +e`, a failed install is invisible and non-fatal — the script prints `OK: Python CDK dependencies installed` and proceeds to `cdk deploy` anyway. On a clean runner this leaves `aws_cdk` uninstalled, and `cdk deploy` (which synths via `python3 app.py`) fails with `ModuleNotFoundError: No module named 'aws_cdk'`. This is not discoverable by reading the files — the script reports success even when the install failed — it surfaces only by running the deploy on a clean runner.

## Changes

- **`security/ai-incident-response-playbook-builder/validation.yaml`**: add `setup_commands` to install the demo's own `infrastructure/cdk/requirements.txt` before deploy, with a comment quoting the offending `deploy-cdk.sh` lines so it's clear this isn't redundant with the shared script's install.
- **`.kiro/steering/contributor-guide.md`**: document the gotcha in the Demo Validation section — add `setup_commands` and `pythonpath_repo_root` to the schema table (both already used by the reference demo but previously undocumented) and a new 'Python CDK demos: declare your own deps (failure-derived)' subsection explaining why the dependency must be declared, plus the related `pythonpath_repo_root` note for the direct-`cdk destroy` path.

## Testing

Failure mode was verified on a real GitHub-hosted `ubuntu-latest` runner (the silent pip failure → `ModuleNotFoundError: No module named 'aws_cdk'` chain). Docs-and-config-only change; no demo runtime code modified.