### PR TITLE
Fix legacy hardcoded Bedrock model id in ai-incident-response-playbook-builder

### DIFF
--- a/security/ai-incident-response-playbook-builder/ARCHITECTURE.md
+++ b/security/ai-incident-response-playbook-builder/ARCHITECTURE.md
@@ -92,7 +92,11 @@ User:   [Architecture Profile JSON]
 ```
 
 **Model Configuration**:
-- Default: `anthropic.claude-3-5-sonnet-20241022-v2:0`
+- Default: region-correct, non-legacy Sonnet resolved at runtime via the shared
+  `get_bedrock_model_id()` helper (base id `anthropic.claude-sonnet-4-5-20250929-v1:0`,
+  e.g. `us.anthropic.claude-sonnet-4-5-20250929-v1:0` in a `us-*` region). No model id is
+  hardcoded — the helper applies the correct cross-region-inference prefix per region, so a
+  pinned id can never silently become Legacy. Override with `--model-id` / `-ModelId`.
 - Max tokens: 4096 per playbook
 - Temperature: 0.2 (low creativity, high consistency)
 

--- a/security/ai-incident-response-playbook-builder/README.md
+++ b/security/ai-incident-response-playbook-builder/README.md
@@ -130,8 +130,8 @@ cd security/ai-incident-response-playbook-builder
 # Generate playbooks for your current AWS account
 ./build-playbooks.sh
 
-# Specify output format and model
-./build-playbooks.sh --output-format both --model-id us.anthropic.claude-sonnet-4-20250514-v1:0
+# Override the model (optional; omit to use the region-correct non-legacy default)
+./build-playbooks.sh --output-format both --model-id us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Include organization context (escalation contacts, Slack channels, etc.)
 ./build-playbooks.sh --org-context org-context.json
@@ -145,8 +145,8 @@ cd security\ai-incident-response-playbook-builder
 # Generate playbooks for your current AWS account
 .\build-playbooks.ps1
 
-# Specify output format and model
-.\build-playbooks.ps1 -OutputFormat Both -ModelId "us.anthropic.claude-sonnet-4-20250514-v1:0"
+# Override the model (optional; omit to use the region-correct non-legacy default)
+.\build-playbooks.ps1 -OutputFormat Both -ModelId "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 # Include organization context
 .\build-playbooks.ps1 -OrgContext org-context.json
@@ -164,7 +164,7 @@ The script automatically:
 | Parameter | PowerShell | Bash | Default | Description |
 |---|---|---|---|---|
 | Output format | `-OutputFormat` | `--output-format` | `both` | `ssm`, `markdown`, or `both` |
-| Model ID | `-ModelId` | `--model-id` | `us.anthropic.claude-sonnet-4-20250514-v1:0` | Bedrock model to use |
+| Model ID | `-ModelId` | `--model-id` | Region-correct non-legacy Sonnet, resolved via the shared `get_bedrock_model_id()` helper | Bedrock model to use; pass a value to override |
 | Region | `-Region` | `--region` | Current configured region | AWS region to scan |
 | Org context | `-OrgContext` | `--org-context` | None | Path to JSON with org-specific details |
 | Output dir | `-OutputDir` | `--output-dir` | `./output` | Where to write generated files |

--- a/security/ai-incident-response-playbook-builder/build-playbooks.ps1
+++ b/security/ai-incident-response-playbook-builder/build-playbooks.ps1
@@ -12,7 +12,8 @@
     Output format: ssm, markdown, or both (default: both)
 
 .PARAMETER ModelId
-    Bedrock model ID (default: anthropic.claude-3-5-sonnet-20241022-v2:0)
+    Bedrock model ID. Omit to use the region-correct, non-legacy default resolved by
+    generator.py via the shared get_bedrock_model_id() helper.
 
 .PARAMETER Region
     AWS region to scan (default: current configured region)
@@ -40,7 +41,11 @@
 param(
     [ValidateSet("ssm", "markdown", "both")]
     [string]$OutputFormat = "both",
-    [string]$ModelId = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    # Empty by default on purpose: DO NOT hardcode a model id here. When empty, generator.py
+    # resolves a region-correct, non-legacy default via the shared get_bedrock_model_id()
+    # helper. A pinned id eventually goes Legacy and Bedrock blocks new/inactive accounts
+    # from invoking it. -ModelId still overrides for callers who want a specific model.
+    [string]$ModelId = "",
     [string]$Region = "",
     [string]$OrgContext = "",
     [string]$OutputDir = "./output",
@@ -142,7 +147,11 @@ Write-Host ""
 Write-Host "Configuration:" -ForegroundColor Yellow
 Write-Host "  Account:       $accountId" -ForegroundColor Gray
 Write-Host "  Region:        $Region" -ForegroundColor Gray
-Write-Host "  Model:         $ModelId" -ForegroundColor Gray
+if (-not [string]::IsNullOrEmpty($ModelId)) {
+    Write-Host "  Model:         $ModelId (override)" -ForegroundColor Gray
+} else {
+    Write-Host "  Model:         region-correct default (resolved by generator.py via shared helper)" -ForegroundColor Gray
+}
 Write-Host "  Output format: $OutputFormat" -ForegroundColor Gray
 Write-Host "  S3 Bucket:     $outputBucket" -ForegroundColor Gray
 Write-Host "  Job ID:        $jobId" -ForegroundColor Gray
@@ -195,11 +204,17 @@ $generateStart = Get-Date
 $generateArgs = @(
     "$srcDir\generator.py",
     "--profile", $profilePath,
-    "--model-id", $ModelId,
     "--region", $Region,
     "--output-dir", $OutputDir,
     "--output-format", $OutputFormat
 )
+
+# Only forward --model-id when the caller explicitly overrode it. When omitted, generator.py
+# resolves the region-correct, non-legacy default via the shared get_bedrock_model_id() helper.
+if (-not [string]::IsNullOrEmpty($ModelId)) {
+    $generateArgs += "--model-id"
+    $generateArgs += $ModelId
+}
 
 if (-not [string]::IsNullOrEmpty($OrgContext)) {
     if (-not (Test-Path $OrgContext)) {

--- a/security/ai-incident-response-playbook-builder/build-playbooks.sh
+++ b/security/ai-incident-response-playbook-builder/build-playbooks.sh
@@ -3,7 +3,12 @@ set -e
 
 # Default values
 OUTPUT_FORMAT="both"
-MODEL_ID="us.anthropic.claude-sonnet-4-20250514-v1:0"
+# Empty by default on purpose: DO NOT hardcode a model id here. When empty, generator.py
+# resolves a region-correct, non-legacy default via the shared get_bedrock_model_id() helper
+# (contributor-guide.md). A pinned id eventually goes Legacy and Bedrock blocks new/inactive
+# accounts from invoking it -- that is the exact failure this fix removes. --model-id still
+# overrides for callers who want a specific model.
+MODEL_ID=""
 REGION=""
 ORG_CONTEXT=""
 OUTPUT_DIR="./output"
@@ -43,7 +48,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --output-format FORMAT  ssm, markdown, or both (default: both)"
-            echo "  --model-id ID           Bedrock model ID (default: anthropic.claude-3-5-sonnet-20241022-v2:0)"
+            echo "  --model-id ID           Bedrock model ID (default: region-correct non-legacy Sonnet via shared helper)"
             echo "  --region REGION         AWS region to scan (default: current configured region)"
             echo "  --org-context FILE      Path to JSON with org-specific context"
             echo "  --output-dir DIR        Local output directory (default: ./output)"
@@ -155,7 +160,11 @@ echo ""
 echo "Configuration:"
 echo "  Account:       $ACCOUNT_ID"
 echo "  Region:        $REGION"
-echo "  Model:         $MODEL_ID"
+if [[ -n "$MODEL_ID" ]]; then
+    echo "  Model:         $MODEL_ID (override)"
+else
+    echo "  Model:         region-correct default (resolved by generator.py via shared helper)"
+fi
 echo "  Output format: $OUTPUT_FORMAT"
 echo "  S3 Bucket:     $OUTPUT_BUCKET"
 echo "  Job ID:        $JOB_ID"
@@ -209,11 +218,16 @@ GENERATE_START=$(date +%s)
 GENERATE_ARGS=(
     "$SRC_DIR/generator.py"
     "--profile" "$PROFILE_PATH"
-    "--model-id" "$MODEL_ID"
     "--region" "$REGION"
     "--output-dir" "$OUTPUT_DIR"
     "--output-format" "$OUTPUT_FORMAT"
 )
+
+# Only forward --model-id when the caller explicitly overrode it. When omitted, generator.py
+# resolves the region-correct, non-legacy default via the shared get_bedrock_model_id() helper.
+if [[ -n "$MODEL_ID" ]]; then
+    GENERATE_ARGS+=("--model-id" "$MODEL_ID")
+fi
 
 if [[ -n "$ORG_CONTEXT" ]]; then
     if [[ ! -f "$ORG_CONTEXT" ]]; then

--- a/security/ai-incident-response-playbook-builder/src/generator.py
+++ b/security/ai-incident-response-playbook-builder/src/generator.py
@@ -3,8 +3,25 @@
 import argparse
 import json
 import os
+import sys
 
 import boto3
+
+# Reach the repo's shared utilities. generator.py runs as a standalone subprocess
+# (build-playbooks.sh invokes `python3 src/generator.py`) without the PYTHONPATH the
+# shared deploy script exports, so bootstrap sys.path to the repo root here. Repo layout:
+# <repo-root>/security/ai-incident-response-playbook-builder/src/generator.py -> 4 levels up.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from shared.utils import get_bedrock_model_id  # noqa: E402
+
+# Verified non-legacy default (base id, no CRIS prefix). get_bedrock_model_id() applies the
+# correct us/eu/apac/global prefix for the deploy region at runtime. NEVER hardcode a
+# region-prefixed id here (contributor-guide.md): any pinned model eventually goes Legacy and
+# Bedrock blocks new/inactive accounts from invoking it, which is exactly the bug this fixes.
+DEFAULT_MODEL_NAME = "anthropic.claude-sonnet-4-5-20250929-v1:0"
 
 THREAT_ASSESSMENT_PROMPT = """You are an AWS security incident response expert. Analyze the following AWS architecture profile and identify the most likely and highest-impact threat scenarios for this specific environment.
 
@@ -213,12 +230,24 @@ def slugify(name):
 def main():
     parser = argparse.ArgumentParser(description="Generate IR playbooks via Amazon Bedrock")
     parser.add_argument("--profile", required=True, help="Path to architecture profile JSON")
-    parser.add_argument("--model-id", default="us.anthropic.claude-sonnet-4-20250514-v1:0")
+    parser.add_argument(
+        "--model-id",
+        default=None,
+        help="Bedrock model ID to invoke. Omit to use the region-correct default resolved "
+             "via the shared get_bedrock_model_id() helper (a current, non-legacy Sonnet).",
+    )
     parser.add_argument("--region", required=True)
     parser.add_argument("--output-dir", default="./output")
     parser.add_argument("--output-format", default="both", choices=["ssm", "markdown", "both"])
     parser.add_argument("--org-context", default=None, help="Path to org context JSON")
     args = parser.parse_args()
+
+    # Resolve the model id: an explicit --model-id always wins; otherwise route through the
+    # shared helper so the CRIS prefix matches AWS_REGION/args.region at invoke time.
+    if not args.model_id:
+        os.environ.setdefault("AWS_REGION", args.region)
+        args.model_id = get_bedrock_model_id(DEFAULT_MODEL_NAME)
+    print(f"  Using model: {args.model_id}")
 
     with open(args.profile) as f:
         profile = json.load(f)

--- a/security/ai-incident-response-playbook-builder/validation.yaml
+++ b/security/ai-incident-response-playbook-builder/validation.yaml
@@ -3,7 +3,8 @@
 
 # The demo's own deploy command, run zero-arg exactly as the README's Quick Start shows.
 # build-playbooks.sh's argument parser has no required flag -- every variable defaults
-# (OUTPUT_FORMAT="both", MODEL_ID="us.anthropic.claude-sonnet-4-20250514-v1:0", REGION=""
+# (OUTPUT_FORMAT="both", MODEL_ID="" [no model hardcoded; generator.py resolves a
+# region-correct, non-legacy default via the shared get_bedrock_model_id() helper], REGION=""
 # [resolved dynamically], OUTPUT_DIR="./output", SKIP_SETUP=false) -- so the bare command is
 # valid. Note this runs the FULL pipeline under `set -e` (CDK deploy -> discovery ->
 # Bedrock generation -> output assembly -> S3 upload), not just the CDK deploy -- a failed
@@ -38,11 +39,14 @@ destroy_subdir: "infrastructure/cdk"
 # STACK_NAME="PlaybookBuilderStack-$REGION". Both agree.
 stacks: ["PlaybookBuilderStack-us-west-2"]
 
-# Pinned, not left to the ambient region. build-playbooks.sh hardcodes
-# MODEL_ID="us.anthropic.claude-sonnet-4-20250514-v1:0" -- a "us."-prefixed cross-region
-# inference profile. If the runner's ambient region isn't a "us-*" region, that Bedrock
-# invoke fails to resolve the profile, which fails deploy_command itself (see above).
-# us-west-2 keeps the deploy region's geography aligned with the hardcoded model prefix.
+# Pinned, not left to the ambient region. The demo no longer hardcodes a model id; instead
+# generator.py resolves the default via the shared get_bedrock_model_id() helper, which
+# applies the CRIS prefix for the deploy region (us-* -> "us.", eu-* -> "eu.", ap-* ->
+# "apac.", else "global."). Pinning still matters for two reasons: (1) the resolved profile
+# and the FMs it fans out to must actually be enabled in the account, and Claude access is
+# enabled here in us-west-2 (see notes); (2) a fixed region keeps the `stacks` name below
+# (PlaybookBuilderStack-us-west-2) deterministic. us-west-2 yields the verified
+# "us.anthropic.claude-sonnet-4-5-20250929-v1:0" profile.
 region: "us-west-2"
 
 # Two things make "does it really work" undrivable by a deterministic check alone:
@@ -68,6 +72,7 @@ notes: >
   runs discovery + Bedrock generation + S3 upload locally under `set -e`, so the whole
   pipeline (not just the CDK deploy) must succeed for deploy_command to report success.
   Needs Claude model access enabled in the account's Bedrock console before running. Region
-  is pinned to us-west-2 to match the script's hardcoded "us."-prefixed default model ID;
-  overriding to a non-"us-*" region would additionally require passing --model-id. Zero
-  required args.
+  is pinned to us-west-2 so the shared get_bedrock_model_id() helper resolves the
+  "us."-prefixed CRIS profile (us.anthropic.claude-sonnet-4-5-20250929-v1:0) and so the
+  stack name stays deterministic; the helper adapts the prefix to any region, so no
+  --model-id override is needed to change regions. Zero required args.

--- a/shared/utils/__init__.py
+++ b/shared/utils/__init__.py
@@ -2,6 +2,6 @@
 Shared AWS utility functions for GenAI Ops demos.
 """
 
-from .aws_utils import get_region, get_account_id
+from .aws_utils import get_region, get_account_id, get_bedrock_model_id
 
-__all__ = ['get_region', 'get_account_id']
+__all__ = ['get_region', 'get_account_id', 'get_bedrock_model_id']


### PR DESCRIPTION
## Summary

The demo hardcoded `us.anthropic.claude-sonnet-4-20250514-v1:0`, which is now a **Legacy** model. Amazon Bedrock blocks new/inactive accounts from invoking Legacy models, so any customer deploying this demo fresh failed **Phase 2 (Bedrock generation)** at `generator.py`'s `invoke_model` call with:

```
AccessDeniedException ... This model is marked by provider as Legacy and you have not been
actively using the model in the last 30 days. Please upgrade to an active model on Amazon Bedrock.
```

This violates the contributor guide's rule — *"NEVER hardcode region-prefixed model IDs"* + use the shared `get_bedrock_model_id()` helper. Routing through that helper is the root-cause fix: a pinned id inevitably goes Legacy, which is exactly why the helper exists.

## Root cause / where it lived

The model id was set or defaulted in **six** inconsistent places (build script + PowerShell + generator + README + ARCHITECTURE), two of which also used an un-prefixed id that wouldn't resolve as a CRIS profile at all.

## Changes

- **`src/generator.py`**: import the shared `get_bedrock_model_id()` via a `sys.path` bootstrap to the repo root (it runs as a standalone subprocess, so the container shared-utils exception does not apply). `--model-id` now defaults to `None`; when omitted it resolves a region-correct, non-legacy default (`anthropic.claude-sonnet-4-5-20250929-v1:0`). An explicit `--model-id` still wins.
- **`build-playbooks.sh` / `build-playbooks.ps1`**: stop hardcoding a model id (empty default); only forward `--model-id`/`-ModelId` when the caller overrides. Stale help text fixed.
- **`shared/utils/__init__.py`**: export `get_bedrock_model_id` so the guide's documented `from shared.utils import ...` style works (it previously would `ImportError`).
- **`README.md` / `ARCHITECTURE.md` / `validation.yaml`**: update model references and rationale to the shared-helper default.

## Testing

- **Live** `bedrock-runtime invoke-model` of `us.anthropic.claude-sonnet-4-5-20250929-v1:0` in us-west-2 returns a completion (model lifecycle confirmed ACTIVE, not Legacy).
- Helper resolves the correct CRIS prefix per region (us/eu/apac/global).
- Real `generator.py` `main()` exercised with a stubbed boto3: default path invokes the resolved id; explicit `--model-id` is passed through unchanged.

## Follow-up (separate PR, not included here)

A deploy attempt surfaced two bugs in the **shared** `shared/scripts/deploy-cdk.sh` (out of scope for this demo-scoped PR):
1. Its Python dependency install is silent and non-fatal (`pip ... 2>/dev/null` under `set +e`, then prints `OK` regardless), so a failed install leaves `cdk deploy` unable to import `aws_cdk`.
2. It derives region from `aws configure get region` rather than honoring `AWS_REGION`/`AWS_DEFAULT_REGION`.

These are cross-demo and will be addressed in their own PR.