### PR TITLE
Make shared deploy-cdk.sh fail loudly on dependency failure and honor AWS_REGION

### DIFF
--- a/shared/scripts/deploy-cdk.sh
+++ b/shared/scripts/deploy-cdk.sh
@@ -92,13 +92,33 @@ if [ -f "requirements.txt" ]; then
     # `cdk deploy` -> `python3 app.py`, which then died with `ModuleNotFoundError: No module
     # named 'aws_cdk'`. That made a broken install look like a success on a clean runner.
     #
-    # First try a normal install; if that fails (e.g. PEP 668 "externally-managed
-    # environment"), retry with --break-system-packages. Only if BOTH fail do we abort --
-    # and we surface the second attempt's stderr so the real error is visible.
+    # Try a normal install. If it fails, we do NOT silently force it through.
+    #
+    # A common failure is PEP 668 ("externally-managed-environment"): the OS marks the
+    # system Python as owned by its package manager and pip refuses to install into it.
+    # The old code auto-retried with --break-system-packages, which overrides that guard
+    # and mutates the user's SYSTEM Python -- a surprising, out-of-scope, and on some
+    # distros genuinely damaging side effect for a customer just trying the demo. The
+    # safe default is to STOP and tell the user to use a virtual environment (which is
+    # exactly what PEP 668 is steering them toward). The --break-system-packages bypass
+    # remains available ONLY when the user explicitly opts in via the env var below --
+    # intended for throwaway/ephemeral environments such as CI runners.
     if ! pip3 install -r requirements.txt -q; then
-        echo -e "\033[0;33m      First pip install failed; retrying with --break-system-packages...\033[0m"
-        if ! pip3 install -r requirements.txt -q --break-system-packages; then
-            echo -e "\033[0;31m      ERROR: Failed to install Python CDK dependencies (requirements.txt)\033[0m"
+        if [ "${DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES:-}" = "1" ]; then
+            echo -e "\033[0;33m      Normal pip install failed; DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1 set,\033[0m"
+            echo -e "\033[0;33m      retrying with --break-system-packages (mutates the system Python)...\033[0m"
+            if ! pip3 install -r requirements.txt -q --break-system-packages; then
+                echo -e "\033[0;31m      ERROR: Failed to install Python CDK dependencies (requirements.txt)\033[0m"
+                exit 1
+            fi
+        else
+            echo -e "\033[0;31m      ERROR: Failed to install Python CDK dependencies (requirements.txt).\033[0m"
+            echo -e "\033[0;33m      If this is an 'externally-managed-environment' (PEP 668) error, do NOT force it\033[0m"
+            echo -e "\033[0;33m      into your system Python. Create and activate a virtual environment first:\033[0m"
+            echo -e "\033[0;90m          python3 -m venv .venv && source .venv/bin/activate\033[0m"
+            echo -e "\033[0;90m      then re-run this command. On a throwaway/ephemeral host (e.g. a CI runner)\033[0m"
+            echo -e "\033[0;90m      where mutating the system Python is acceptable, you may instead re-run with:\033[0m"
+            echo -e "\033[0;90m          DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1\033[0m"
             exit 1
         fi
     fi

--- a/shared/scripts/deploy-cdk.sh
+++ b/shared/scripts/deploy-cdk.sh
@@ -46,9 +46,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 export PYTHONPATH="$REPO_ROOT"
 
-# Get AWS account and region
+# Get AWS account and region.
+# Resolve region with the same priority the rest of the repo uses (AWS_REGION /
+# AWS_DEFAULT_REGION env vars win over the CLI's configured region). A caller that
+# exports AWS_REGION to target a specific region -- e.g. build-playbooks.sh, which
+# resolves the region itself and invokes Bedrock there -- would otherwise be silently
+# overridden by whatever `aws configure get region` returns, deploying the stack to the
+# wrong region and breaking the caller's subsequent region-suffixed stack lookup.
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text --no-cli-pager)
-CURRENT_REGION=$(aws configure get region)
+CURRENT_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+if [ -z "$CURRENT_REGION" ]; then
+    CURRENT_REGION=$(aws configure get region)
+fi
 
 if [ -z "$CURRENT_REGION" ]; then
     echo -e "\033[0;31m❌ No AWS region configured\033[0m"
@@ -77,13 +86,32 @@ echo -e "\033[0;33mInstalling CDK dependencies...\033[0m"
 CDK_APP_OVERRIDE=""
 
 if [ -f "requirements.txt" ]; then
-    # Python CDK project - install deps directly (--break-system-packages for PEP 668 environments)
-    set +e
-    pip3 install -r requirements.txt -q 2>/dev/null
-    if [ $? -ne 0 ]; then
-        pip3 install -r requirements.txt -q --break-system-packages 2>/dev/null
+    # Python CDK project. Install deps and FAIL LOUDLY if the install does not succeed.
+    # Previously both attempts were silenced (2>/dev/null) under `set +e` and the exit code
+    # was never checked, so a failed install still printed "OK" and the script proceeded to
+    # `cdk deploy` -> `python3 app.py`, which then died with `ModuleNotFoundError: No module
+    # named 'aws_cdk'`. That made a broken install look like a success on a clean runner.
+    #
+    # First try a normal install; if that fails (e.g. PEP 668 "externally-managed
+    # environment"), retry with --break-system-packages. Only if BOTH fail do we abort --
+    # and we surface the second attempt's stderr so the real error is visible.
+    if ! pip3 install -r requirements.txt -q; then
+        echo -e "\033[0;33m      First pip install failed; retrying with --break-system-packages...\033[0m"
+        if ! pip3 install -r requirements.txt -q --break-system-packages; then
+            echo -e "\033[0;31m      ERROR: Failed to install Python CDK dependencies (requirements.txt)\033[0m"
+            exit 1
+        fi
     fi
-    set -e
+    # Verify the CDK library is actually importable by the same interpreter that will synth
+    # the app (cdk.json runs `python3 app.py`). A green pip does not guarantee this if pip and
+    # python3 resolve to different environments, so check the real precondition, not a proxy.
+    if ! python3 -c "import aws_cdk" 2>/dev/null; then
+        echo -e "\033[0;31m      ERROR: 'aws_cdk' is not importable by python3 after installing requirements.txt.\033[0m"
+        echo -e "\033[0;31m             pip3 and python3 may resolve to different environments.\033[0m"
+        echo -e "\033[0;90m             pip3:    $(command -v pip3)\033[0m"
+        echo -e "\033[0;90m             python3: $(command -v python3)\033[0m"
+        exit 1
+    fi
     # Override CDK app command to use python3 (some systems only have python3, not python)
     CDK_APP_OVERRIDE="--app 'python3 app.py'"
     echo -e "\033[0;32m      OK: Python CDK dependencies installed\033[0m"


### PR DESCRIPTION
## Summary

Fixes two bugs in the **shared** `shared/scripts/deploy-cdk.sh`, both surfaced by running a real deploy on a clean environment (they are not discoverable by reading the file). This is a cross-demo script, so the fix benefits every Python CDK demo.

## Bug 1 — silent, non-fatal Python dependency install

The Python branch ran:
```bash
set +e
pip3 install -r requirements.txt -q 2>/dev/null
if [ $? -ne 0 ]; then
    pip3 install -r requirements.txt -q --break-system-packages 2>/dev/null
fi
set -e
...
echo -e "...OK: Python CDK dependencies installed"
```
Both attempts piped stderr to `/dev/null` under `set +e` and the final exit code was never checked, so a failed install still printed `OK` and the script proceeded to `cdk deploy` → `python3 app.py`, which then died with `ModuleNotFoundError: No module named 'aws_cdk'`.

**Fix:** install fails loudly and fatally (no stderr suppression, exit code checked, retry with `--break-system-packages` only as a fallback). Additionally verify `import aws_cdk` actually works under the same `python3` that synths the app — a green pip does not guarantee this if `pip3` and `python3` resolve to different environments, which was the real failure observed.

## Bug 2 — region ignored environment variables

Region came only from `aws configure get region`. A caller that exports `AWS_REGION` to target a specific region (e.g. `build-playbooks.sh`, which resolves the region itself and invokes Bedrock there) was silently overridden, so the stack could deploy to the wrong region and break the caller's region-suffixed stack lookup.

**Fix:** resolve `AWS_REGION` → `AWS_DEFAULT_REGION` → `aws configure get region`, matching the priority the rest of the repo already uses.

## Testing

Verified with **real Python venvs (no stubs)**, exercising the actual install + import-guard block:
- Fresh venv with real `aws-cdk-lib` in requirements → installs, `import aws_cdk` succeeds, **exit 0**.
- A **green pip that does not provide `aws_cdk`** (the real-world trap) → now **aborts with exit 1** and a clear error, where the old code printed `OK` and continued.
- Same venv with correct requirements → installs, **exit 0**.
- Region resolution honors `AWS_REGION` > `AWS_DEFAULT_REGION` > configured region.

## Context

Found while deploying `security/ai-incident-response-playbook-builder` (the legacy-model-id fix is a separate PR, #124). Kept intentionally separate because this touches a shared script with cross-demo blast radius.