### PR TITLE
Bring deploy-cdk.ps1 to parity with the deploy-cdk.sh fixes (#125)

### DIFF
--- a/shared/scripts/deploy-cdk.ps1
+++ b/shared/scripts/deploy-cdk.ps1
@@ -13,9 +13,20 @@ param(
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $env:PYTHONPATH = $repoRoot
 
-# Get AWS account and region
+# Get AWS account and region.
+# Resolve region with the same priority the rest of the repo uses (AWS_REGION /
+# AWS_DEFAULT_REGION env vars win over the CLI's configured region). A caller that sets
+# $env:AWS_REGION to target a specific region would otherwise be silently overridden by
+# whatever `aws configure get region` returns, deploying the stack to the wrong region
+# and breaking the caller's subsequent region-suffixed stack lookup. Mirrors deploy-cdk.sh.
 $accountId = aws sts get-caller-identity --query Account --output text --no-cli-pager
-$currentRegion = aws configure get region
+$currentRegion = if (-not [string]::IsNullOrEmpty($env:AWS_REGION)) {
+    $env:AWS_REGION
+} elseif (-not [string]::IsNullOrEmpty($env:AWS_DEFAULT_REGION)) {
+    $env:AWS_DEFAULT_REGION
+} else {
+    aws configure get region
+}
 
 if ([string]::IsNullOrEmpty($currentRegion)) {
     Write-Host "ERROR: No AWS region configured" -ForegroundColor Red
@@ -41,7 +52,55 @@ try {
     Write-Host ""
     Write-Host "Installing CDK dependencies..." -ForegroundColor Yellow
     if (Test-Path "requirements.txt") {
-        pip install -r requirements.txt -q 2>$null
+        # Python CDK project. Install deps and FAIL LOUDLY if the install does not succeed.
+        # Previously stderr was silenced (2>$null) and $LASTEXITCODE was never checked, so a
+        # failed install still printed "OK" and the script proceeded to `cdk bootstrap`/`deploy`
+        # -> `python3 app.py`, which then died with `ModuleNotFoundError: No module named
+        # 'aws_cdk'`. That made a broken install look like a success on a clean host.
+        #
+        # On failure we do NOT silently force it through. A common failure is PEP 668
+        # ("externally-managed-environment"): pip refuses to install into an OS-managed Python.
+        # The safe default is to STOP and guide the user to a virtual environment. The
+        # --break-system-packages bypass (which mutates the system Python) is available ONLY
+        # when the user explicitly opts in via DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1 --
+        # intended for throwaway/ephemeral hosts such as CI runners. Mirrors deploy-cdk.sh.
+        $prevErrorAction = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        pip install -r requirements.txt -q
+        $pipExitCode = $LASTEXITCODE
+        if ($pipExitCode -ne 0) {
+            if ($env:DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES -eq "1") {
+                Write-Host "      Normal pip install failed; DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1 set," -ForegroundColor Yellow
+                Write-Host "      retrying with --break-system-packages (mutates the system Python)..." -ForegroundColor Yellow
+                pip install -r requirements.txt -q --break-system-packages
+                $pipExitCode = $LASTEXITCODE
+                if ($pipExitCode -ne 0) {
+                    $ErrorActionPreference = $prevErrorAction
+                    Write-Host "      ERROR: Failed to install Python CDK dependencies (requirements.txt)" -ForegroundColor Red
+                    exit 1
+                }
+            } else {
+                $ErrorActionPreference = $prevErrorAction
+                Write-Host "      ERROR: Failed to install Python CDK dependencies (requirements.txt)." -ForegroundColor Red
+                Write-Host "      If this is an 'externally-managed-environment' (PEP 668) error, do NOT force it" -ForegroundColor Yellow
+                Write-Host "      into your system Python. Create and activate a virtual environment first:" -ForegroundColor Yellow
+                Write-Host "          python3 -m venv .venv; .\.venv\Scripts\Activate.ps1" -ForegroundColor Gray
+                Write-Host "      then re-run this command. On a throwaway/ephemeral host (e.g. a CI runner)" -ForegroundColor Gray
+                Write-Host "      where mutating the system Python is acceptable, you may instead re-run with:" -ForegroundColor Gray
+                Write-Host "          `$env:DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES = '1'" -ForegroundColor Gray
+                exit 1
+            }
+        }
+        $ErrorActionPreference = $prevErrorAction
+        # Verify the CDK library is actually importable by the interpreter that will synth the
+        # app (cdk.json runs `python3 app.py`). A green pip does not guarantee this if pip and
+        # python3 resolve to different environments, so check the real precondition, not a proxy.
+        python3 -c "import aws_cdk" 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "      ERROR: 'aws_cdk' is not importable by python3 after installing requirements.txt." -ForegroundColor Red
+            Write-Host "             pip and python3 may resolve to different environments." -ForegroundColor Red
+            exit 1
+        }
         Write-Host "      OK: Python CDK dependencies installed" -ForegroundColor Green
     } elseif (Test-Path "package.json") {
         # Install when node_modules is missing OR incomplete. A previous interrupted


### PR DESCRIPTION
## Summary

Follow-up to #125. That PR fixed two bugs in the **bash** shared CDK deploy script (`shared/scripts/deploy-cdk.sh`), but the **PowerShell** sibling `shared/scripts/deploy-cdk.ps1` still had both — leaving Windows users exposed to the exact failure #125 fixed. The contributor guide requires both `.ps1` and `.sh`, so they should behave the same. This brings the PowerShell script to parity.

## Bug 1 — silent Python install (was actually worse than bash)

```powershell
pip install -r requirements.txt -q 2>$null
Write-Host "      OK: Python CDK dependencies installed"
```
stderr was silenced **and** `$LASTEXITCODE` was never checked, so `OK` printed unconditionally even when the install failed — then `cdk bootstrap`/`deploy` → `python3 app.py` died with `ModuleNotFoundError: No module named 'aws_cdk'`.

**Fix (mirrors #125):** check the exit code and fail loudly with **venv guidance** on failure; retain `--break-system-packages` only behind an explicit `DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1` opt-in (throwaway/CI hosts); and verify `python3 -c "import aws_cdk"` actually succeeds under the interpreter that synths the app.

## Bug 2 — region ignored environment variables

Region came only from `aws configure get region`. **Fix:** resolve `$env:AWS_REGION` → `$env:AWS_DEFAULT_REGION` → configured region, matching `deploy-cdk.sh` and the rest of the repo.

## Testing / caveat

⚠️ **No PowerShell runtime was available on the authoring host, so this `.ps1` was NOT executed.** The logic is a direct mirror of the bash version merged in #125, which *was* verified behaviorally with real `pip3`/venvs (normal install succeeds; a green pip that doesn't provide `aws_cdk` aborts; opt-in gates the bypass). **A reviewer on Windows/pwsh should sanity-run it** before merge.

## Context

Found while reviewing #125's blast radius across the other demos. The bash and PowerShell shared scripts are meant to be behavioral equivalents; shipping the bash fix alone left a cross-platform gap.