### PR TITLE
deploy-cdk.sh: pin one python interpreter for install, verify, and synth

### DIFF
--- a/shared/scripts/deploy-cdk.sh
+++ b/shared/scripts/deploy-cdk.sh
@@ -92,6 +92,20 @@ if [ -f "requirements.txt" ]; then
     # `cdk deploy` -> `python3 app.py`, which then died with `ModuleNotFoundError: No module
     # named 'aws_cdk'`. That made a broken install look like a success on a clean runner.
     #
+    # CRITICAL: pin ONE interpreter for install, verification, AND synthesis.
+    # `cdk.json` runs the app as `python3 app.py`, and `npx cdk` may resolve `python3` to a
+    # DIFFERENT interpreter than a bare `pip3`/`python3` in this shell (very common with
+    # pyenv shims or multiple python3 installs). If we `pip3 install` into interpreter A but
+    # cdk synthesizes with interpreter B, the deps are invisible and synth dies with
+    # ModuleNotFoundError even though install "succeeded". So we resolve $PY once here and use
+    # it for install (`$PY -m pip`), verification (`$PY -c import aws_cdk`), AND the CDK app
+    # override below (`--app "$PY app.py"`), guaranteeing all three are the same interpreter.
+    PY="$(command -v python3 || true)"
+    if [ -z "$PY" ]; then
+        echo -e "\033[0;31m      ERROR: python3 not found on PATH; cannot install/synthesize the Python CDK app\033[0m"
+        exit 1
+    fi
+
     # Try a normal install. If it fails, we do NOT silently force it through.
     #
     # A common failure is PEP 668 ("externally-managed-environment"): the OS marks the
@@ -103,11 +117,11 @@ if [ -f "requirements.txt" ]; then
     # exactly what PEP 668 is steering them toward). The --break-system-packages bypass
     # remains available ONLY when the user explicitly opts in via the env var below --
     # intended for throwaway/ephemeral environments such as CI runners.
-    if ! pip3 install -r requirements.txt -q; then
+    if ! "$PY" -m pip install -r requirements.txt -q; then
         if [ "${DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES:-}" = "1" ]; then
             echo -e "\033[0;33m      Normal pip install failed; DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1 set,\033[0m"
             echo -e "\033[0;33m      retrying with --break-system-packages (mutates the system Python)...\033[0m"
-            if ! pip3 install -r requirements.txt -q --break-system-packages; then
+            if ! "$PY" -m pip install -r requirements.txt -q --break-system-packages; then
                 echo -e "\033[0;31m      ERROR: Failed to install Python CDK dependencies (requirements.txt)\033[0m"
                 exit 1
             fi
@@ -122,19 +136,21 @@ if [ -f "requirements.txt" ]; then
             exit 1
         fi
     fi
-    # Verify the CDK library is actually importable by the same interpreter that will synth
-    # the app (cdk.json runs `python3 app.py`). A green pip does not guarantee this if pip and
-    # python3 resolve to different environments, so check the real precondition, not a proxy.
-    if ! python3 -c "import aws_cdk" 2>/dev/null; then
-        echo -e "\033[0;31m      ERROR: 'aws_cdk' is not importable by python3 after installing requirements.txt.\033[0m"
-        echo -e "\033[0;31m             pip3 and python3 may resolve to different environments.\033[0m"
-        echo -e "\033[0;90m             pip3:    $(command -v pip3)\033[0m"
-        echo -e "\033[0;90m             python3: $(command -v python3)\033[0m"
+    # Verify the CDK library is importable by the EXACT interpreter that will synth the app
+    # ($PY, which we also pin into --app below). A green pip does not guarantee this if pip
+    # and the synth interpreter differ, so check the real precondition against $PY itself.
+    if ! "$PY" -c "import aws_cdk" 2>/dev/null; then
+        echo -e "\033[0;31m      ERROR: 'aws_cdk' is not importable by the interpreter that will synth the app.\033[0m"
+        echo -e "\033[0;90m             interpreter: $PY\033[0m"
+        echo -e "\033[0;90m             This usually means pip installed into a different python than \$PY.\033[0m"
+        echo -e "\033[0;90m             Use a virtual environment so pip and python3 are the same interpreter.\033[0m"
         exit 1
     fi
-    # Override CDK app command to use python3 (some systems only have python3, not python)
-    CDK_APP_OVERRIDE="--app 'python3 app.py'"
-    echo -e "\033[0;32m      OK: Python CDK dependencies installed\033[0m"
+    # Pin the CDK app command to the SAME interpreter we installed into and verified above,
+    # by absolute path -- not a bare `python3`, which npx cdk could re-resolve to a different
+    # interpreter that lacks the deps (the root cause of the ModuleNotFoundError-after-OK bug).
+    CDK_APP_OVERRIDE="--app '$PY app.py'"
+    echo -e "\033[0;32m      OK: Python CDK dependencies installed (interpreter: $PY)\033[0m"
 elif [ -f "package.json" ]; then
     # TypeScript/JavaScript CDK project.
     # Install when node_modules is missing OR incomplete. A previous interrupted


### PR DESCRIPTION
## Summary

Follow-up to #125. That PR added an `import aws_cdk` verification to the shared bash CDK deploy script, but the guard checked the **shell's** `python3` while `cdk` synthesizes the app via `cdk.json`'s bare `python3 app.py` — and `npx cdk` can resolve `python3` to a **different** interpreter than the shell's (very common with pyenv shims or multiple `python3` installs).

**Consequence:** pip installs into interpreter A, the guard passes against A, but `cdk` synthesizes with interpreter B that lacks the deps — so the script prints `OK: Python CDK dependencies installed` and then `cdk bootstrap` → `python3 app.py` still dies with `ModuleNotFoundError: No module named 'aws_cdk'`. The #125 guard gave a **false green** for this environment class.

## Fix

Resolve one interpreter, `$PY = $(command -v python3)`, up front and use it consistently for all three steps so they can't diverge:
- **install:** `$PY -m pip install ...` (not bare `pip3`)
- **verify:** `$PY -c 'import aws_cdk'`
- **synth:** `CDK_APP_OVERRIDE="--app '$PY app.py'"` — pins the CDK app to that interpreter by absolute path instead of a bare `python3` that `npx cdk` could re-resolve.

## Testing — verified end-to-end on a real account

Ran the actual `ai-incident-response-playbook-builder` deploy in us-west-2 (account 078127730839):
- **Before this change** (on #125's merged script): died at `cdk bootstrap` → `python3 app.py` with `ModuleNotFoundError: No module named 'aws_cdk'`, immediately after printing `OK: dependencies installed`.
- **With this change:** `OK: Python CDK dependencies installed (interpreter: /Users/.../python3)`, CDK **bootstrap completed**, and **`PlaybookBuilderStack-us-west-2` reached `CREATE_COMPLETE`**. Discovery ran (409 resources). Stack was then destroyed cleanly (`cdk destroy` → `DELETE_COMPLETE`), so the teardown path works too.

(The Bedrock generation step still fails **on this branch only**, because this branch is cut from `main` and lacks the separate legacy-model-id fix in PR #124 — the failure is the expected `Legacy model` `AccessDeniedException`, unrelated to this interpreter change.)

## Context

Discovered while trying to validate #124 with a real deploy: the deploy couldn't get past bootstrap because of this interpreter mismatch, which traced back to a gap in my own #125 guard.