### PR TITLE
feature-relevance: fail loudly on pip failure, pin interpreter, fix destroy PYTHONPATH

### DIFF
--- a/observability/aws-feature-relevance-notification-system/deploy-all.sh
+++ b/observability/aws-feature-relevance-notification-system/deploy-all.sh
@@ -34,7 +34,28 @@ echo "Using region: $REGION"
 if [ "$DESTROY_INFRA" = true ]; then
     echo "Destroying infrastructure..."
     cd "$CDK_DIR"
-    cdk destroy "$STACK_NAME" --force
+    # `cdk destroy` re-synthesizes app.py, so both aws_cdk AND the repo's `shared` package must
+    # be importable by the interpreter cdk uses. app.py does `from shared.utils.aws_utils import
+    # get_region`, which needs the repo root on PYTHONPATH -- the deploy path exports it below,
+    # but the destroy path exits before that, so export it here too. Pin --app to an explicit
+    # python3 and check both imports so destroy fails with a clear message instead of a cryptic
+    # ModuleNotFoundError.
+    export PYTHONPATH="$SCRIPT_DIR/../..:$PYTHONPATH"
+    PY="$(command -v python3 || true)"
+    if [ -z "$PY" ] || ! "$PY" -c "import aws_cdk" 2>/dev/null; then
+        echo "ERROR: 'aws_cdk' is not importable by python3, which cdk needs to synthesize the app for destroy."
+        echo "       Install the CDK deps first (in a venv): python3 -m pip install -r requirements.txt"
+        exit 1
+    fi
+    if ! PYTHONPATH="$SCRIPT_DIR/../..:$PYTHONPATH" "$PY" -c "import shared.utils.aws_utils" 2>/dev/null; then
+        echo "ERROR: the repo's 'shared' package is not importable, which app.py needs to synthesize for destroy."
+        echo "       Run this script from within the repo so \$PYTHONPATH can reach the repo root."
+        exit 1
+    fi
+    if ! cdk destroy "$STACK_NAME" --force --app "$PY app.py"; then
+        echo "ERROR: CDK destroy failed"
+        exit 1
+    fi
     echo "Infrastructure destruction completed"
     exit 0
 fi
@@ -43,13 +64,55 @@ fi
 echo ""
 echo "Installing CDK dependencies..."
 cd "$CDK_DIR"
-pip3 install -r requirements.txt -q 2>/dev/null || pip3 install -r requirements.txt -q --break-system-packages 2>/dev/null
 
-# Install Lambda dependencies (no Docker required)
+# Pin ONE python interpreter for install, verification, and CDK synth. `cdk` synthesizes the
+# app via cdk.json (python3 app.py); if we install into a different python than cdk uses, the
+# deps are invisible and synth dies with ModuleNotFoundError. Resolve $PY once and reuse it.
+PY="$(command -v python3 || true)"
+if [ -z "$PY" ]; then
+    echo "ERROR: python3 not found on PATH; cannot install/synthesize the CDK app"
+    exit 1
+fi
+
+# Install CDK deps and FAIL LOUDLY. Previously both attempts piped stderr to /dev/null and the
+# exit code was never checked, so a failed install still fell through to `cdk deploy` and died
+# with ModuleNotFoundError: No module named 'aws_cdk'. We also no longer auto-force
+# --break-system-packages (which mutates the user's system Python); that bypass is opt-in only
+# via DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1, for throwaway/ephemeral hosts such as CI runners.
+if ! "$PY" -m pip install -r requirements.txt -q; then
+    if [ "${DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES:-}" = "1" ]; then
+        echo "Normal pip install failed; DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1 set, retrying with --break-system-packages (mutates system Python)..."
+        if ! "$PY" -m pip install -r requirements.txt -q --break-system-packages; then
+            echo "ERROR: Failed to install CDK dependencies (requirements.txt)"
+            exit 1
+        fi
+    else
+        echo "ERROR: Failed to install CDK dependencies (requirements.txt)."
+        echo "If this is an 'externally-managed-environment' (PEP 668) error, do NOT force it into"
+        echo "your system Python. Create and activate a virtual environment first:"
+        echo "    python3 -m venv .venv && source .venv/bin/activate"
+        echo "then re-run. On a throwaway/ephemeral host you may instead re-run with:"
+        echo "    DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1"
+        exit 1
+    fi
+fi
+# Verify aws_cdk is importable by the exact interpreter that will synth the app.
+if ! "$PY" -c "import aws_cdk" 2>/dev/null; then
+    echo "ERROR: 'aws_cdk' is not importable by $PY after installing requirements.txt."
+    echo "       Use a virtual environment so pip and python3 are the same interpreter."
+    exit 1
+fi
+
+# Install Lambda dependencies (no Docker required). These are vendored into the function
+# directory via -t and zipped into the Lambda, so a SILENT failure here ships a Lambda that is
+# missing its deps and only fails at RUNTIME in AWS -- much harder to diagnose. Fail loudly.
+# (--break-system-packages is irrelevant for a -t target install, so it is not used here.)
 echo ""
 echo "Installing Lambda dependencies..."
-pip3 install -r "$SCRIPT_DIR/lambdas/rss-ingestion/requirements.txt" -t "$SCRIPT_DIR/lambdas/rss-ingestion/" -q --no-compile 2>/dev/null || \
-pip3 install -r "$SCRIPT_DIR/lambdas/rss-ingestion/requirements.txt" -t "$SCRIPT_DIR/lambdas/rss-ingestion/" -q --no-compile --break-system-packages 2>/dev/null
+if ! "$PY" -m pip install -r "$SCRIPT_DIR/lambdas/rss-ingestion/requirements.txt" -t "$SCRIPT_DIR/lambdas/rss-ingestion/" -q --no-compile; then
+    echo "ERROR: Failed to install Lambda dependencies for rss-ingestion"
+    exit 1
+fi
 
 # Set PYTHONPATH for shared utilities
 export PYTHONPATH="$SCRIPT_DIR/../..:$PYTHONPATH"
@@ -63,12 +126,11 @@ if [ -n "$SLACK_WEBHOOK_URL" ]; then
     CONTEXT_ARGS="$CONTEXT_ARGS --context slack_webhook_url=$SLACK_WEBHOOK_URL"
 fi
 
-# Deploy CDK stack
+# Deploy CDK stack. Pin --app to the SAME interpreter ($PY) we installed into and verified
+# above, so cdk does not re-resolve `python3` to a different interpreter that lacks the deps.
 echo ""
 echo "Deploying CDK stack..."
-cdk deploy "$STACK_NAME" --require-approval never $CONTEXT_ARGS
-
-if [ $? -ne 0 ]; then
+if ! cdk deploy "$STACK_NAME" --require-approval never --app "$PY app.py" $CONTEXT_ARGS; then
     echo "ERROR: CDK deployment failed"
     exit 1
 fi


### PR DESCRIPTION
## Summary

`observability/aws-feature-relevance-notification-system/deploy-all.sh` installs its Python deps **inline** (it does not use the shared `deploy-cdk.sh`), so the #125/#129 shared-script hardening never reached it. It carried the original silent-failure bug for **both** its CDK deps and its Lambda vendored deps:

```bash
pip3 install -r requirements.txt -q 2>/dev/null || pip3 install -r requirements.txt -q --break-system-packages 2>/dev/null
```

stderr silenced, exit code unchecked, and `--break-system-packages` auto-forced (mutating the user's system Python). A failed CDK install fell through to `cdk deploy` → `ModuleNotFoundError`; a failed Lambda `-t` install shipped a Lambda **missing its deps** that only fails at runtime in AWS.

## Changes (mirror the shared-script pattern from #125/#129)

- **Pin one `$PY` interpreter** for install (`$PY -m pip`), verification (`$PY -c 'import aws_cdk'`), and `cdk --app "$PY app.py"` so synth uses the same interpreter the deps were installed into.
- **Both installs fail loudly and fatally.** `--break-system-packages` is opt-in only via `DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1` (throwaway/CI); the default is stop-and-guide toward a venv. Not used for the `-t` Lambda install (irrelevant there).
- **Destroy path fix:** export `PYTHONPATH` to the repo root and verify both `aws_cdk` **and** the repo `shared` package import before `cdk destroy`. `app.py` does `from shared.utils.aws_utils import get_region`, which the destroy path (which exits before the deploy-time `PYTHONPATH` export) previously lacked → `ModuleNotFoundError: No module named 'shared'`. **Found by actually running `--destroy-infra`** during testing.

## Testing — verified end-to-end on a real account (us-west-2)

- **Deploy:** the full **31-resource** stack (4 Lambdas incl. the vendored-dep RSS ingestion function, 2 DynamoDB tables, KMS key, Secrets Manager secret, SQS DLQ, Step Functions state machine, EventBridge rule) reached **`CREATE_COMPLETE`**.
- **Destroy:** `./deploy-all.sh --destroy-infra` (the fixed path) tore the stack down to **`DELETE_COMPLETE`**. The first destroy attempt exposed the `shared`/PYTHONPATH bug above, which this PR fixes; the re-run succeeded cleanly.
- Isolated real-`pip`/venv checks also confirm: happy path installs + verifies (exit 0); a failing install aborts with venv guidance (exit 1) instead of silently continuing.

## Context

This is finding #1 from the post-#125 blast-radius review (demos with their own copied silent-pip pattern). `anycompany-it-demo-portal` has a milder, opt-in-only instance of the same pattern — tracked separately, not in this PR.