### PR TITLE
feature-relevance (Windows): PowerShell parity for the deploy-all.sh loud-pip fix

### DIFF
--- a/observability/aws-feature-relevance-notification-system/deploy-all.ps1
+++ b/observability/aws-feature-relevance-notification-system/deploy-all.ps1
@@ -31,22 +31,83 @@ Write-Host "Using region: $Region" -ForegroundColor Cyan
 # Destroy mode
 if ($DestroyInfra) {
     Write-Host "Destroying infrastructure..." -ForegroundColor Red
+    # `cdk destroy` re-synthesizes app.py, which does `from shared.utils.aws_utils import
+    # get_region` and imports aws_cdk. Both must be importable by the interpreter cdk uses, so
+    # set PYTHONPATH to the repo root (the deploy path sets it below, but destroy exits first)
+    # and verify both imports -- otherwise destroy fails with a cryptic ModuleNotFoundError.
+    $WorkspaceRoot = (Resolve-Path "$ScriptDir\..\..").Path
+    $env:PYTHONPATH = "$WorkspaceRoot;$env:PYTHONPATH"
+    python -c "import aws_cdk" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: 'aws_cdk' is not importable by python, which cdk needs to synthesize the app for destroy." -ForegroundColor Red
+        Write-Host "       Install the CDK deps first (in a venv): python -m pip install -r requirements.txt" -ForegroundColor Yellow
+        exit 1
+    }
+    python -c "import shared.utils.aws_utils" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: the repo's 'shared' package is not importable, which app.py needs to synthesize for destroy." -ForegroundColor Red
+        Write-Host "       Run this script from within the repo so PYTHONPATH can reach the repo root." -ForegroundColor Yellow
+        exit 1
+    }
     Push-Location $CdkDir
     cdk destroy $StackName @cdkAppArg --force
+    $destroyExit = $LASTEXITCODE
     Pop-Location
+    if ($destroyExit -ne 0) {
+        Write-Host "ERROR: CDK destroy failed" -ForegroundColor Red
+        exit 1
+    }
     Write-Host "Infrastructure destruction completed" -ForegroundColor Green
     exit 0
 }
 
-# Install CDK dependencies
+# Install CDK dependencies and FAIL LOUDLY. $ErrorActionPreference="Stop" does NOT trap a
+# native command's non-zero exit, so we must check $LASTEXITCODE explicitly -- otherwise a
+# failed pip install falls through to `cdk deploy` and dies with ModuleNotFoundError:
+# No module named 'aws_cdk'. We also do not auto-force --break-system-packages (which mutates
+# the system Python); that bypass is opt-in only via DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1.
 Write-Host "`nInstalling CDK dependencies..." -ForegroundColor Yellow
 Push-Location $CdkDir
 python -m pip install -r requirements.txt -q
+if ($LASTEXITCODE -ne 0) {
+    if ($env:DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES -eq "1") {
+        Write-Host "Normal pip install failed; DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1 set, retrying with --break-system-packages (mutates system Python)..." -ForegroundColor Yellow
+        python -m pip install -r requirements.txt -q --break-system-packages
+        if ($LASTEXITCODE -ne 0) {
+            Pop-Location
+            Write-Host "ERROR: Failed to install CDK dependencies (requirements.txt)" -ForegroundColor Red
+            exit 1
+        }
+    } else {
+        Pop-Location
+        Write-Host "ERROR: Failed to install CDK dependencies (requirements.txt)." -ForegroundColor Red
+        Write-Host "If this is an 'externally-managed-environment' (PEP 668) error, do NOT force it into" -ForegroundColor Yellow
+        Write-Host "your system Python. Create and activate a virtual environment first:" -ForegroundColor Yellow
+        Write-Host "    python -m venv .venv; .\.venv\Scripts\Activate.ps1" -ForegroundColor Gray
+        Write-Host "then re-run. On a throwaway/ephemeral host you may instead re-run with:" -ForegroundColor Gray
+        Write-Host "    `$env:DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES = '1'" -ForegroundColor Gray
+        exit 1
+    }
+}
+# Verify aws_cdk is importable by the interpreter that will synth the app.
+python -c "import aws_cdk" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Pop-Location
+    Write-Host "ERROR: 'aws_cdk' is not importable by python after installing requirements.txt." -ForegroundColor Red
+    Write-Host "       Use a virtual environment so pip and python are the same interpreter." -ForegroundColor Yellow
+    exit 1
+}
 Pop-Location
 
-# Install Lambda dependencies (no Docker required)
+# Install Lambda dependencies (no Docker required). These are vendored into the function dir
+# via -t and zipped into the Lambda, so a SILENT failure ships a Lambda missing its deps that
+# only fails at RUNTIME in AWS. Fail loudly. (--break-system-packages is irrelevant for -t.)
 Write-Host "Installing Lambda dependencies..." -ForegroundColor Yellow
 python -m pip install -r "$ScriptDir\lambdas\rss-ingestion\requirements.txt" -t "$ScriptDir\lambdas\rss-ingestion" -q --no-compile
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "ERROR: Failed to install Lambda dependencies for rss-ingestion" -ForegroundColor Red
+    exit 1
+}
 
 # Set PYTHONPATH for shared utilities
 $WorkspaceRoot = (Resolve-Path "$ScriptDir\..\..").Path


### PR DESCRIPTION
## Summary

PowerShell parity for **#130** (which fixes the bash `deploy-all.sh`). Kept as a **separate PR** because the `.ps1` cannot be executed on the authoring host — it needs a Windows/pwsh reviewer, and shouldn't gate #130's fully-validated bash change.

`deploy-all.ps1` had the same class of issues as the bash script:

1. **Install exit codes unchecked (both CDK and Lambda deps).** Note `$ErrorActionPreference = 'Stop'` does **not** trap a native command's non-zero exit, so a failed `python -m pip install` silently fell through to `cdk deploy` → `ModuleNotFoundError: No module named 'aws_cdk'`; a failed Lambda `-t` install shipped a Lambda missing its deps (fails at runtime).
2. **Destroy-path `shared`/PYTHONPATH gap.** `cdk destroy` ran before `$env:PYTHONPATH` was set (that happens later in the deploy path), so re-synthesizing `app.py` (`from shared.utils.aws_utils import get_region`) would fail with `ModuleNotFoundError: No module named 'shared'` — the exact destroy bug found by running `--destroy-infra` on the bash side.

## Changes (mirror the validated bash fix in #130)

- Check `$LASTEXITCODE` after both installs; fail loudly. `--break-system-packages` opt-in only via `DEPLOY_CDK_ALLOW_BREAK_SYSTEM_PACKAGES=1`; default is venv guidance. Not used for the `-t` Lambda install.
- Verify `import aws_cdk` after the CDK install.
- Destroy path: set `$env:PYTHONPATH` to the repo root and verify both `aws_cdk` and the repo `shared` package import before `cdk destroy`; check the destroy exit code.

## Testing / caveat

⚠️ **No PowerShell runtime on the authoring host — this `.ps1` was NOT executed.** The logic is a direct mirror of the bash version, which **was** validated end-to-end on a real account in #130 (full stack deploy → `CREATE_COMPLETE`, destroy → `DELETE_COMPLETE`, including the destroy `shared`/PYTHONPATH fix). **A Windows/pwsh reviewer should sanity-run this before merge.**

## Relationship to other PRs

- Depends conceptually on **#130** (same demo, bash side) but is independent at the file level (touches only `deploy-all.ps1`), so it can be reviewed/merged on its own.
- Same split rationale as the shared script's #125 (bash) → #127 (PowerShell).