### PR TITLE
Fix SSM document generation: robust JSON extraction + visible failures (#133)

### DIFF
--- a/security/ai-incident-response-playbook-builder/src/generator.py
+++ b/security/ai-incident-response-playbook-builder/src/generator.py
@@ -169,33 +169,39 @@ def generate_playbook(bedrock, model_id, threat, profile, org_context=None):
 
 
 def extract_json(text):
-    """Robustly extract JSON from Bedrock response that may contain markdown or extra text."""
+    """Robustly extract JSON from a Bedrock response that may wrap it in prose or markdown.
+
+    Bedrock (Claude) commonly returns the SSM document wrapped in a ```json ... ``` fence, and
+    the JSON itself frequently contains embedded shell snippets -- i.e. NESTED ``` fences and
+    stray braces inside string values. The decisive step below scans for the first JSON value
+    (`{` or `[`) and uses json.JSONDecoder().raw_decode(), which consumes exactly one complete,
+    balanced JSON value and ignores whatever trails it (a closing fence, prose, a nested code
+    block). That is immune to the nested-fence / trailing-`}` problems that broke the previous
+    rfind('```')- and rfind('}')-based slicing.
+    """
     text = text.strip()
-    # Try direct parse first
+
+    # Fast path: the whole response is already valid JSON.
     try:
         return json.loads(text)
     except json.JSONDecodeError:
         pass
-    # Strip markdown code fences
-    if "```" in text:
-        # Find content between first ``` and last ```
-        start = text.find("```")
-        first_newline = text.find("\n", start)
-        end = text.rfind("```")
-        if first_newline != -1 and end > first_newline:
-            text = text[first_newline + 1:end].strip()
-            try:
-                return json.loads(text)
-            except json.JSONDecodeError:
-                pass
-    # Find first { and last } to extract JSON object
-    first_brace = text.find("{")
-    last_brace = text.rfind("}")
-    if first_brace != -1 and last_brace > first_brace:
+
+    # Scan forward for the first JSON value opener and let raw_decode() consume one balanced
+    # value from there. Trying each candidate handles a leading ```json fence, a prose preamble,
+    # or any other junk before the JSON without depending on where it ENDS.
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(text):
+        if ch not in "{[":
+            continue
         try:
-            return json.loads(text[first_brace:last_brace + 1])
+            value, _ = decoder.raw_decode(text, i)
+            return value
         except json.JSONDecodeError:
-            pass
+            # This opener did not start a complete JSON value (e.g. a stray '{' in prose);
+            # keep scanning for the next candidate.
+            continue
+
     raise json.JSONDecodeError("No valid JSON found in response", text, 0)
 
 
@@ -276,6 +282,8 @@ def main():
     os.makedirs(playbooks_dir, exist_ok=True)
     os.makedirs(ssm_dir, exist_ok=True)
 
+    ssm_attempted = 0
+    ssm_failures = []  # (threat_name, error) for an end-of-run summary
     for i, threat in enumerate(threats, 1):
         name = threat.get("threat_name", f"threat-{i}")
         slug = slugify(name)
@@ -289,6 +297,7 @@ def main():
 
         # Generate SSM document
         if args.output_format in ("ssm", "both"):
+            ssm_attempted += 1
             try:
                 playbook_text = playbook_md if args.output_format == "both" else generate_playbook(
                     bedrock, args.model_id, threat, profile, org_context
@@ -296,10 +305,31 @@ def main():
                 ssm_doc = generate_ssm_document(bedrock, args.model_id, playbook_text, profile)
                 with open(os.path.join(ssm_dir, f"{slug}.json"), "w") as f:
                     json.dump(ssm_doc, f, indent=2)
-            except (json.JSONDecodeError, KeyError, Exception) as e:
+            # Catch only the failure mode SSM generation is expected to produce (an unparseable
+            # model response). We deliberately do NOT catch bare Exception here: an unexpected
+            # error (e.g. a Bedrock ClientError/throttle, a bug) should surface loudly rather
+            # than be silently counted as "SSM failed" -- that broad catch is what previously
+            # hid a systemic parse failure behind a per-item warning.
+            except json.JSONDecodeError as e:
                 print(f"    ⚠ SSM document generation failed for {name}: {e}")
+                ssm_failures.append((name, str(e)))
 
     print(f"  Generated {len(threats)} playbooks")
+
+    # Make partial SSM failure VISIBLE. Previously every SSM doc could fail and the run still
+    # looked successful; surface a clear count, and fail loudly if EVERY attempt failed (which
+    # indicates a systemic problem rather than one bad response).
+    if ssm_attempted:
+        ssm_ok = ssm_attempted - len(ssm_failures)
+        print(f"  Generated {ssm_ok}/{ssm_attempted} SSM documents")
+        if ssm_failures:
+            print(f"  ⚠ {len(ssm_failures)} SSM document(s) failed to generate:")
+            for tname, err in ssm_failures:
+                print(f"      - {tname}: {err}")
+            if ssm_ok == 0:
+                print("  ERROR: ALL SSM document generations failed -- this indicates a "
+                      "systemic problem (e.g. response parsing), not a one-off bad response.")
+                sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #133.

## Root cause (confirmed via a live Bedrock call, not inferred)

The model returns a **complete, valid** SSM Automation document wrapped in a ```json … ``` markdown fence — `stop_reason: end_turn`, `output_tokens` well under the 4096 cap. So it was **neither empty nor token-truncated** (both were earlier guesses in the issue).

`extract_json` stripped fences with `rfind('```')` and `rfind('}')`. That breaks whenever the SSM JSON contains a **nested ``` fence** or stray braces **inside a string value** — extremely common for IR automation documents full of embedded CLI commands. `rfind` grabbed an *inner* fence, the slice truncated the JSON mid-document, and parsing failed with `No valid JSON found in response: line 1 column 1 (char 0)`. This is why a run could produce 12 playbooks but **0** SSM documents. The failure was then hidden by a swallowing `except (json.JSONDecodeError, KeyError, Exception)`, so the run still looked successful.

## Fix

**`extract_json`** — replace the `rfind`-based fence/brace slicing with a forward scan for the first `{`/`[` plus `json.JSONDecoder().raw_decode()`, which consumes exactly one complete, balanced JSON value and ignores any trailing content (closing fence, prose, nested code block). Immune to nested fences and trailing braces in strings.

**`main()`** — narrow the catch to `json.JSONDecodeError` (unexpected errors like Bedrock `ClientError` now surface loudly instead of being silently counted as an SSM failure), track attempts/failures, print a `Generated N/M SSM documents` summary, and **exit non-zero if every SSM attempt failed** (systemic) so it can never again silently report success with zero output.

This is a **cross-platform runtime fix in `generator.py`** — no PowerShell or deploy-script change (both `build-playbooks.sh` and `.ps1` invoke the same Python).

## Testing

- **9 `extract_json` unit cases** pass, including the decisive one: fenced JSON whose string value contains a nested ```bash fence **and** a literal `{not json}` (the exact production failure) — the recovered value matches byte-for-byte. Empty / no-JSON / truncated inputs still correctly raise (we don't silently accept partial docs).
- **Live Bedrock response** (real `us.anthropic.claude-sonnet-4-5-20250929-v1:0` SSM call) now extracts to a valid `schemaVersion: 0.3` document (7 `mainSteps`).
- **`main()` summary** exercised with a stubbed all-SSM-fail run: prints `Generated 0/1 SSM documents`, lists the failure, and exits 1 — where the old code exited 0 and looked successful.

## Context

Found while validating #124 end-to-end (a real deploy produced 12 playbooks, 0 SSM docs). Independent of #124's model-id change.